### PR TITLE
[FIX] Discord PM to the wrong user (#11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/)
 
 
+## [1.0.1] - 2021-02-09
+
+### Fixed
+
+- Discord PM on approval or reject goes to the reviewer instead of the requester (#11)
+
+
 ## [1.0.0] - 2021-02-06
 
 This has now been tested long enough by my corp, it's time to fully release the

--- a/aasrp/__init__.py
+++ b/aasrp/__init__.py
@@ -6,5 +6,5 @@ a couple of variable to use throughout the app
 
 default_app_config: str = "aasrp.apps.AaSrpConfig"
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 __title__ = "Ship Replacement"

--- a/aasrp/views.py
+++ b/aasrp/views.py
@@ -897,7 +897,7 @@ def ajax_srp_request_approve(
             request_code=srp_request_code, srp_link__srp_code=srp_code
         )
 
-        user = srp_request.creator
+        requester = srp_request.creator
         srp_payout = srp_request.payout_amount
         srp_isk_loss = srp_request.loss_amount
 
@@ -933,7 +933,7 @@ def ajax_srp_request_approve(
         )
 
         notify(
-            user=user,
+            user=requester,
             title=_("SRP Request Approved"),
             level="success",
             message=notification_message,
@@ -944,7 +944,7 @@ def ajax_srp_request_approve(
             import aadiscordbot.tasks
 
             aadiscordbot.tasks.send_direct_message_by_user_id.delay(
-                request.user.pk, notification_message
+                requester.pk, notification_message
             )
 
         data.append({"success": True, "message": _("SRP request has been approved")})
@@ -980,11 +980,10 @@ def ajax_srp_request_deny(
                     request_code=srp_request_code, srp_link__srp_code=srp_code
                 )
 
-                user = srp_request.creator
+                requester = srp_request.creator
 
                 srp_request.payout_amount = 0
                 srp_request.request_status = AaSrpRequestStatus.REJECTED
-                # srp_request.reject_info = reject_info
                 srp_request.save()
 
                 # save reject reason as comment for this request
@@ -1022,7 +1021,7 @@ def ajax_srp_request_deny(
                 )
 
                 notify(
-                    user=user,
+                    user=requester,
                     title=_("SRP Request Rejected"),
                     level="danger",
                     message=notification_message,
@@ -1033,7 +1032,7 @@ def ajax_srp_request_deny(
                     import aadiscordbot.tasks
 
                     aadiscordbot.tasks.send_direct_message_by_user_id.delay(
-                        request.user.pk, notification_message
+                        requester.pk, notification_message
                     )
 
                 data.append(


### PR DESCRIPTION
Fixing an issue where the discord PM on SRP request approval or rejection went out to the reviewer instead of eh requester.

Closes #11