### PR TITLE
Django 4 compat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ## [In Development] - Unreleased
 
+### Fixed
+
+- [Compatibility] AA 3.x / Django 4 :: ImportError: cannot import name
+  'ugettext_lazy' from 'django.utils.translation'
+
 
 ## [1.11.2] - 2022-02-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ## [In Development] - Unreleased
 
+
+## [1.12.0] - 2022-02-28
+
 ### Fixed
 
 - [Compatibility] AA 3.x / Django 4 :: ImportError: cannot import name

--- a/aasrp/__init__.py
+++ b/aasrp/__init__.py
@@ -4,5 +4,5 @@ a couple of variable to use throughout the app
 
 default_app_config: str = "aasrp.apps.AaSrpConfig"
 
-__version__ = "1.11.2"
+__version__ = "1.12.0"
 __title__ = "Ship Replacement"

--- a/aasrp/auth_hooks.py
+++ b/aasrp/auth_hooks.py
@@ -3,7 +3,7 @@ hook into AA
 """
 
 # Django
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 # Alliance Auth
 from allianceauth import hooks

--- a/aasrp/form.py
+++ b/aasrp/form.py
@@ -9,7 +9,7 @@ import re
 from django import forms
 from django.forms import ModelForm
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 # AA SRP
 from aasrp.constants import (

--- a/testauth/urls.py
+++ b/testauth/urls.py
@@ -1,10 +1,10 @@
 # Django
-from django.conf.urls import include, url
+from django.urls import include, re_path
 
 # Alliance Auth
 from allianceauth import urls
 
 urlpatterns = [
     # Alliance Auth URLs
-    url(r"", include(urls)),
+    re_path(r"", include(urls)),
 ]


### PR DESCRIPTION
## Description

### Fixed

- [Compatibility] AA 3.x / Django 4 :: ImportError: cannot import name
  'ugettext_lazy' from 'django.utils.translation'


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not
  work as expected)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
