### PR TITLE
Next Release - v1.13.3

### DIFF
--- a/.github/workflows/automated-checks.yml
+++ b/.github/workflows/automated-checks.yml
@@ -60,7 +60,7 @@ jobs:
 
       # Upload the SARIF file generated in the previous step
       - name: Upload SARIF results file
-        uses: github/codeql-action/upload-sarif@v1
+        uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: results.sarif
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,6 +22,7 @@ repos:
         args: [ --remove ]
       - id: detect-private-key
       - id: check-added-large-files
+        args: [ --maxkb=1000 ]
       - id: check-ast  # Is it valid Python?
       - id: debug-statements  # Check for debugger imports and py37+ breakpoint() calls
       - id: check-merge-conflict
@@ -41,13 +42,13 @@ repos:
       - id: text-unicode-replacement-char
 
   - repo: https://github.com/adamchainz/django-upgrade
-    rev: 1.5.0
+    rev: 1.7.0
     hooks:
       - id: django-upgrade
-        args: [ --target-version, "3.2" ]
+        args: [ --target-version=3.2 ]
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.32.0
+    rev: v2.32.1
     hooks:
       - id: pyupgrade
         args: [ --py37-plus ]
@@ -71,12 +72,14 @@ repos:
     rev: 22.3.0
     hooks:
       - id: black
+        args: [ --target-version=py37 ]
 
   - repo: https://github.com/asottile/blacken-docs
     rev: v1.12.1
     hooks:
       - id: blacken-docs
         additional_dependencies: [ black==22.3.0 ]
+        args: [ --target-version=py37 ]
 
   - repo: https://github.com/asottile/setup-cfg-fmt
     rev: v1.20.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ## [In Development] - Unreleased
 
+### Changed
+
+- Logic for Discord PMs changed/optimized. We now check if the user has a
+  Discord account registered with Alliance Auth first, so we don't have to do all
+  the other checks if the user doesn't
+
 
 ## [1.13.2] - 2022-05-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ## [In Development] - Unreleased
 
+### Fixed
+
+- AttributError exception in `get_main_character_from_user` when the user doesn't
+  have a main character anymore
+
 ### Changed
 
 - Logic for Discord PMs changed/optimized. We now check if the user has a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ## [In Development] - Unreleased
 
+
+## [1.13.3] - 2022-06-05
+
 ### Fixed
 
 - AttributError exception in `get_main_character_from_user` when the user doesn't

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 - AttributError exception in `get_main_character_from_user` when the user doesn't
   have a main character anymore
+- Possible RelatedObjectDoesNotExist error in `get_user_for_character`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 - AttributError exception in `get_main_character_from_user` when the user doesn't
   have a main character anymore
+- Possible RelatedObjectDoesNotExist error in `get_main_for_character`
 - Possible RelatedObjectDoesNotExist error in `get_user_for_character`
 
 ### Changed

--- a/aasrp/__init__.py
+++ b/aasrp/__init__.py
@@ -2,5 +2,5 @@
 a couple of variable to use throughout the app
 """
 
-__version__ = "1.13.2"
+__version__ = "1.13.3"
 __title__ = "Ship Replacement"

--- a/aasrp/helper/character.py
+++ b/aasrp/helper/character.py
@@ -90,15 +90,15 @@ def get_main_for_character(character: EveCharacter) -> EveCharacter:
     :param character:
     """
 
-    return_value = None
-
     try:
         userprofile = character.character_ownership.user.profile
-    except EveCharacter.character_ownership.RelatedObjectDoesNotExist:
+    except (
+        EveCharacter.character_ownership.RelatedObjectDoesNotExist,
+        CharacterOwnership.user.RelatedObjectDoesNotExist,
+    ):
         return_value = None
     else:
-        if userprofile:
-            return_value = userprofile.main_character
+        return_value = userprofile.main_character
 
     return return_value
 

--- a/aasrp/helper/character.py
+++ b/aasrp/helper/character.py
@@ -8,6 +8,7 @@ from django.contrib.auth.models import User
 from django.utils.translation import gettext_lazy as _
 
 # Alliance Auth
+from allianceauth.authentication.models import CharacterOwnership
 from allianceauth.eveonline.models import EveCharacter
 
 # AA SRP
@@ -111,13 +112,13 @@ def get_user_for_character(character: EveCharacter) -> User:
 
     try:
         userprofile = character.character_ownership.user.profile
-    except EveCharacter.character_ownership.RelatedObjectDoesNotExist:
+    except (
+        EveCharacter.character_ownership.RelatedObjectDoesNotExist,
+        CharacterOwnership.user.RelatedObjectDoesNotExist,
+    ):
         return_value = get_sentinel_user()
     else:
-        if userprofile is None:
-            return_value = get_sentinel_user()
-        else:
-            return_value = userprofile.user
+        return_value = userprofile.user
 
     return return_value
 

--- a/aasrp/helper/character.py
+++ b/aasrp/helper/character.py
@@ -131,13 +131,14 @@ def get_main_character_from_user(user: User) -> str:
     :rtype:
     """
 
-    user_main_character = user.username
+    if user is None:
+        sentinel_user = get_sentinel_user()
+
+        return sentinel_user.username
 
     try:
-        user_profile = user.profile
+        return_value = user.profile.main_character.character_name
     except AttributeError:
-        pass
-    else:
-        user_main_character = user_profile.main_character.character_name
+        return str(user)
 
-    return user_main_character
+    return return_value

--- a/aasrp/helper/icons.py
+++ b/aasrp/helper/icons.py
@@ -180,7 +180,7 @@ def get_srp_request_details_icon(
     srp_request_details_icon = (
         f'<button data-link="{button_request_details_url}" '
         'data-toggle="modal" '
-        f'data-target="#srp-request-details" '
+        'data-target="#srp-request-details" '
         f'data-modal-title="{title}" '
         f'data-modal-button-confirm="{modal_button_confirm}" '
         'class="btn btn-primary btn-sm btn-icon-aasrp" '

--- a/aasrp/tests/test_helper_character.py
+++ b/aasrp/tests/test_helper_character.py
@@ -20,10 +20,12 @@ from app_utils.testing import (
 
 # AA SRP
 from aasrp.helper.character import (
+    get_formatted_character_name,
     get_main_character_from_user,
     get_main_for_character,
     get_user_for_character,
 )
+from aasrp.helper.eve_images import get_character_portrait_from_evecharacter
 from aasrp.models import get_sentinel_user
 
 
@@ -41,6 +43,137 @@ class TestSentinelUser(TestCase):
         sentinel_user = get_sentinel_user()
 
         self.assertEqual(sentinel_user.username, "deleted")
+
+
+class TestGetFormattedCharacterName(TestCase):
+    """
+    Tests for get_formatted_character_name
+    """
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        """
+        Set up groups and users
+        """
+
+        super().setUpClass()
+        cls.group = Group.objects.create(name="Enterprise Crew")
+
+        cls.user_main_character = create_fake_user(
+            character_id=1001, character_name="William T. Riker"
+        )
+
+        cls.alt_character = create_eve_character(
+            character_id=1002, character_name="Thomas Riker"
+        )
+
+        add_character_to_user(cls.user_main_character, cls.alt_character)
+
+        cls.character_without_profile = create_eve_character(
+            character_id=1003, character_name="Christopher Pike"
+        )
+
+    def test_should_return_formatted_character_name(self):
+        """
+        Test should return formatted character name
+        :return:
+        """
+
+        html = get_formatted_character_name(character=self.alt_character)
+        expected_html = (
+            "<small class='text-muted'>"
+            f"{self.alt_character.alliance_ticker} "
+            f"[{self.alt_character.corporation_ticker}] "
+            f"</small><br>{self.alt_character.character_name}"
+        )
+
+        self.assertEqual(html, expected_html)
+
+    def test_should_return_formatted_character_name_with_copy_icon(self):
+        """
+        Test should return formatted character name with copy icon
+        :return:
+        """
+
+        html = get_formatted_character_name(
+            character=self.alt_character, with_copy_icon=True
+        )
+
+        copy_icon = (
+            f"<i "
+            f'class="aa-srp-fa-icon aa-srp-fa-icon-right copy-text-fa-icon far fa-copy" '
+            f'data-clipboard-text="{self.alt_character.character_name}" '
+            f'title="Copy character name to clipboard"></i>'
+        )
+
+        expected_html = (
+            "<small class='text-muted'>"
+            f"{self.alt_character.alliance_ticker} "
+            f"[{self.alt_character.corporation_ticker}] "
+            f"</small><br>{self.alt_character.character_name}{copy_icon}"
+        )
+
+        self.assertEqual(html, expected_html)
+
+    def test_should_return_formatted_character_name_with_portrait(self):
+        """
+        Test should return formatted character name with portrait
+        :return:
+        """
+
+        html = get_formatted_character_name(
+            character=self.alt_character, with_portrait=True, inline=False
+        )
+
+        formatted_character_name = (
+            "<small class='text-muted'>"
+            f"{self.alt_character.alliance_ticker} "
+            f"[{self.alt_character.corporation_ticker}] "
+            f"</small><br>{self.alt_character.character_name}"
+        )
+
+        character_portrait_html = get_character_portrait_from_evecharacter(
+            character=self.alt_character, size=32, as_html=True
+        )
+
+        expected_html = (
+            f"{character_portrait_html}<br>"
+            "<span class='aasrp-character-portrait-character-name'>"
+            f"{formatted_character_name}"
+            "</span>"
+        )
+
+        self.assertEqual(html, expected_html)
+
+    def test_should_return_formatted_character_name_with_portrait_inline(self):
+        """
+        Test should return formatted character name with portrait (inline)
+        :return:
+        """
+
+        html = get_formatted_character_name(
+            character=self.alt_character, with_portrait=True
+        )
+
+        formatted_character_name = (
+            "<small class='text-muted'>"
+            f"{self.alt_character.alliance_ticker} "
+            f"[{self.alt_character.corporation_ticker}] "
+            f"</small><br>{self.alt_character.character_name}"
+        )
+
+        character_portrait_html = get_character_portrait_from_evecharacter(
+            character=self.alt_character, size=32, as_html=True
+        )
+
+        expected_html = (
+            f"{character_portrait_html}"
+            "<span class='aasrp-character-portrait-character-name'>"
+            f"{formatted_character_name}"
+            "</span>"
+        )
+
+        self.assertEqual(html, expected_html)
 
 
 class TestGetMainForCharacter(TestCase):

--- a/aasrp/tests/test_helper_character.py
+++ b/aasrp/tests/test_helper_character.py
@@ -125,11 +125,8 @@ class TestGetFormattedCharacterName(TestCase):
             character=self.alt_character, with_portrait=True, inline=False
         )
 
-        formatted_character_name = (
-            "<small class='text-muted'>"
-            f"{self.alt_character.alliance_ticker} "
-            f"[{self.alt_character.corporation_ticker}] "
-            f"</small><br>{self.alt_character.character_name}"
+        formatted_character_name = get_formatted_character_name(
+            character=self.alt_character
         )
 
         character_portrait_html = get_character_portrait_from_evecharacter(
@@ -155,11 +152,8 @@ class TestGetFormattedCharacterName(TestCase):
             character=self.alt_character, with_portrait=True
         )
 
-        formatted_character_name = (
-            "<small class='text-muted'>"
-            f"{self.alt_character.alliance_ticker} "
-            f"[{self.alt_character.corporation_ticker}] "
-            f"</small><br>{self.alt_character.character_name}"
+        formatted_character_name = get_formatted_character_name(
+            character=self.alt_character
         )
 
         character_portrait_html = get_character_portrait_from_evecharacter(

--- a/aasrp/tests/test_helper_character.py
+++ b/aasrp/tests/test_helper_character.py
@@ -8,6 +8,7 @@ from django.test import TestCase
 
 # Alliance Auth
 from allianceauth.eveonline.models import EveCharacter
+from allianceauth.tests.auth_utils import AuthUtils
 
 # Alliance Auth (External Libs)
 from app_utils.testing import (
@@ -17,7 +18,11 @@ from app_utils.testing import (
 )
 
 # AA SRP
-from aasrp.helper.character import get_main_for_character, get_user_for_character
+from aasrp.helper.character import (
+    get_main_character_from_user,
+    get_main_for_character,
+    get_user_for_character,
+)
 from aasrp.models import get_sentinel_user
 
 
@@ -128,3 +133,49 @@ class TestHelperCharacter(TestCase):
         returned_user = get_user_for_character(self.alt_character)
 
         self.assertEqual(returned_user, self.user_main_character.profile.user)
+
+    def test_get_main_character_from_user_should_return_character_name(self):
+        """
+        Test should return the main character name for a regular user
+        :return:
+        """
+
+        character_name = get_main_character_from_user(self.user_main_character)
+
+        self.assertEqual(character_name, "William T. Riker")
+
+    def test_get_main_character_from_user_should_return_user_name(self):
+        """
+        Test should return just the user name for a user without a character
+        :return:
+        """
+
+        user = AuthUtils.create_user("John Doe")
+
+        character_name = get_main_character_from_user(user)
+
+        self.assertEqual(character_name, "John Doe")
+
+    def test_get_main_character_from_user_should_return_sentinel_user(self):
+        """
+        Test should return "deleted" as username (Sentinel User)
+        :return:
+        """
+
+        user = get_sentinel_user()
+
+        character_name = get_main_character_from_user(user)
+
+        self.assertEqual(character_name, "deleted")
+
+    def test_get_main_character_from_user_should_return_sentinel_user_for_none(self):
+        """
+        Test shouod return "deleted" (Sentinel User) if user is None
+        :return:
+        """
+
+        user = None
+
+        character_name = get_main_character_from_user(user)
+
+        self.assertEqual(character_name, "deleted")

--- a/aasrp/tests/test_helper_character.py
+++ b/aasrp/tests/test_helper_character.py
@@ -45,7 +45,7 @@ class TestSentinelUser(TestCase):
 
 class TestGetMainForCharacter(TestCase):
     """
-    Testing get_main_for_character
+    Testing for get_main_for_character
     """
 
     @classmethod
@@ -128,7 +128,7 @@ class TestGetMainForCharacter(TestCase):
 
 class TestGetUserForCharacter(TestCase):
     """
-    Test get_user_for_character
+    Tests for get_user_for_character
     """
 
     @classmethod
@@ -209,7 +209,7 @@ class TestGetUserForCharacter(TestCase):
 
 class TestGetMainCharacterFromUser(TestCase):
     """
-    Test get_main_character_from_user
+    Tests for get_main_character_from_user
     """
 
     @classmethod
@@ -241,7 +241,7 @@ class TestGetMainCharacterFromUser(TestCase):
 
     def test_get_main_character_from_user_should_return_user_name(self):
         """
-        Test should return just the user name for a user without a character
+        Test should return just the username for a user without a character
         :return:
         """
 
@@ -265,7 +265,7 @@ class TestGetMainCharacterFromUser(TestCase):
 
     def test_get_main_character_from_user_should_return_sentinel_user_for_none(self):
         """
-        Test shouod return "deleted" (Sentinel User) if user is None
+        Test should return "deleted" (Sentinel User) if user is None
         :return:
         """
 

--- a/aasrp/tests/test_helper_character.py
+++ b/aasrp/tests/test_helper_character.py
@@ -65,7 +65,12 @@ class TestGetMainForCharacter(TestCase):
             character_id=1002, character_name="Thomas Riker"
         )
 
+        cls.alt_character_2 = create_eve_character(
+            character_id=1004, character_name="Jean Luc Riker"
+        )
+
         add_character_to_user(cls.user_main_character, cls.alt_character)
+        add_character_to_user(cls.user_main_character, cls.alt_character_2)
 
         cls.character_without_profile = create_eve_character(
             character_id=1003, character_name="Christopher Pike"
@@ -92,6 +97,20 @@ class TestGetMainForCharacter(TestCase):
         get_main_for_character(self.character_without_profile)
 
         self.assertRaises(EveCharacter.userprofile.RelatedObjectDoesNotExist)
+
+    def test_get_main_for_character_raises_exception_related_object_does_not_exist_2(
+        self,
+    ):
+        """
+        Test if we get `CharacterOwnership.user.RelatedObjectDoesNotExist` as exception
+        :return:
+        """
+
+        self.alt_character_2.character_ownership.user = None
+
+        get_main_for_character(self.alt_character_2)
+
+        self.assertRaises(CharacterOwnership.user.RelatedObjectDoesNotExist)
 
     def test_get_main_for_character_returns_main_character(self):
         """


### PR DESCRIPTION
## Description

### Fixed

### Fixed

- AttributError exception in `get_main_character_from_user` when the user doesn't
  have a main character anymore
- Possible RelatedObjectDoesNotExist error in `get_user_for_character`

### Changed

- Logic for Discord PMs changed/optimized. We now check if the user has a
  Discord account registered with Alliance Auth first, so we don't have to do all
  the other checks if the user doesn't


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not
  work as expected)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
