### PR TITLE
[FIX] MySQL8 migration error

### DIFF
--- a/.github/workflows/automated-checks.yml
+++ b/.github/workflows/automated-checks.yml
@@ -74,11 +74,12 @@ jobs:
       # Set Python and Django version to test for the stable release of AllianceAuth
       matrix:
         # Don't forget to change the Python version for [upload-coverage] as well
-        python-version: [ '3.8', '3.9', '3.10', '3.11-dev' ]
+#        python-version: [ '3.8', '3.9', '3.10', '3.11-dev' ]
+        python-version: [ '3.8', '3.9', '3.10' ]
         # Don't forget to change the Django version for [upload-coverage] as well
         django-version: [ '4.0' ]
 
-    continue-on-error: ${{ matrix.python-version == '3.11-dev' }}
+#    continue-on-error: ${{ matrix.python-version == '3.11-dev' }}
 
     steps:
       - name: Checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ## [1.16.1] - 2022-08-06
 
-### Update Notice
+### Update Information
 
 **This release includes all changes from
 [1.16.0 (YANKED)](https://github.com/ppfeufer/aa-srp/releases/tag/v1.16.0) as well
@@ -24,7 +24,7 @@ following command **before** updating to this version.
 python manage.py migrate aasrp 0006
 ```
 
-This will re-set your migrations to the state of v1.15.2 and you can update as you
+This will re-set your migrations to the state of v1.15.2, and you can update as you
 would normally do from here.
 
 If you haven't installed v1.16.0 yet, you can just update as usual.
@@ -32,7 +32,7 @@ If you haven't installed v1.16.0 yet, you can just update as usual.
 ### Fixed
 
 - Migration error for MySQL8 (`django.db.utils.OperationalError: (1292, "Incorrect
-  datetime value: '0000-00-00 00:00:00' for column 'comment_time' at row 1")`) -
+  datetime value: '0000-00-00 00:00:00' for column 'comment_time' at row 1")`)
   Thanks to Rhaven (on AA support Discord) for reporting and testing this
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ## [In Development] - Unreleased
 
+### Fixed
+
+- Migration error for MySQL8 (`django.db.utils.OperationalError: (1292, "Incorrect
+  datetime value: '0000-00-00 00:00:00' for column 'comment_time' at row 1")`)
+
 
 ## [1.16.0] - 2022-08-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
   datetime value: '0000-00-00 00:00:00' for column 'comment_time' at row 1")`)
 
 
-## [1.16.0] - 2022-08-04
+## [1.16.0] - 2022-08-04 [YANKED]
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ## [In Development] - Unreleased
 
+
+## [1.16.1] - 2022-08-06
+
 ### Update Notice
 
 **This release includes all changes from
@@ -29,7 +32,13 @@ If you haven't installed v1.16.0 yet, you can just update as usual.
 ### Fixed
 
 - Migration error for MySQL8 (`django.db.utils.OperationalError: (1292, "Incorrect
-  datetime value: '0000-00-00 00:00:00' for column 'comment_time' at row 1")`)
+  datetime value: '0000-00-00 00:00:00' for column 'comment_time' at row 1")`) -
+  Thanks to Rhaven (on AA support Discord) for reporting and testing this
+
+### Removed
+
+- Python 3.11 from tests. AA is not tested yet with it, and it's not even stable at
+  the moment.
 
 
 ## [1.16.0] - 2022-08-04 [YANKED]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ## [In Development] - Unreleased
 
+### Update Notice
+
+**This release includes all changes from
+[1.16.0 (YANKED)](https://github.com/ppfeufer/aa-srp/releases/tag/v1.16.0) as well
+as the following:**
+
+If you already installed v1.16.0 and successfully ran migrations, please run the
+following command **before** updating to this version.
+
+```shell
+python manage.py migrate aasrp 0006
+```
+
+This will re-set your migrations to the state of v1.15.2 and you can update as you
+would normally do from here.
+
+If you haven't installed v1.16.0 yet, you can just update as usual.
+
 ### Fixed
 
 - Migration error for MySQL8 (`django.db.utils.OperationalError: (1292, "Incorrect
@@ -15,6 +33,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 
 ## [1.16.0] - 2022-08-04 [YANKED]
+
+**This release has been yanked from Pypi due to a migration error on systems with
+mySQL8**
 
 ### Added
 

--- a/aasrp/__init__.py
+++ b/aasrp/__init__.py
@@ -2,5 +2,5 @@
 A couple of variable to use throughout the app
 """
 
-__version__ = "1.16.0"
+__version__ = "1.16.1"
 __title__ = "Ship Replacement"

--- a/aasrp/migrations/0007_aasrprequestcomment_comment_time_and_more.py
+++ b/aasrp/migrations/0007_aasrprequestcomment_comment_time_and_more.py
@@ -14,7 +14,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name="aasrprequestcomment",
             name="comment_time",
-            field=models.DateTimeField(default=None),
+            field=models.DateTimeField(null=True, blank=True),
         ),
         migrations.AlterField(
             model_name="aasrprequestcomment",

--- a/aasrp/migrations/0008_aasrprequestcomment_new_status_and_more.py
+++ b/aasrp/migrations/0008_aasrprequestcomment_new_status_and_more.py
@@ -47,6 +47,8 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name="aasrprequestcomment",
             name="comment_time",
-            field=models.DateTimeField(default=django.utils.timezone.now),
+            field=models.DateTimeField(
+                default=django.utils.timezone.now, null=True, blank=True
+            ),
         ),
     ]

--- a/aasrp/models.py
+++ b/aasrp/models.py
@@ -298,7 +298,7 @@ class AaSrpRequestComment(models.Model):
         on_delete=models.CASCADE,
     )
 
-    comment_time = models.DateTimeField(default=timezone.now)
+    comment_time = models.DateTimeField(default=timezone.now, null=True, blank=True)
 
     new_status = models.CharField(
         max_length=8, choices=AaSrpRequest.Status.choices, blank=True, default=""

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,6 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
-    Programming Language :: Python :: 3.11
     Topic :: Internet :: WWW/HTTP
     Topic :: Internet :: WWW/HTTP :: Dynamic Content
 home_page = https://github.com/ppfeufer/aa-srp

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [tox]
 isolated_build = True
 envlist =
-    aa_stable-py{38, 39, 310, 311}
+;    aa_stable-py{38, 39, 310, 311}
+    aa_stable-py{38, 39, 310}
 
 [gh-actions]
 python =


### PR DESCRIPTION
## Description

### Fixed

- Migration error for MySQL8 (`django.db.utils.OperationalError: (1292, "Incorrect
  datetime value: '0000-00-00 00:00:00' for column 'comment_time' at row 1")`)
  Thanks to Rhaven (on AA support Discord) for reporting and testing this

### Removed

- Python 3.11 from tests. AA is not tested yet with it, and it's not even stable at
  the moment.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not
  work as expected)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
