### PR TITLE
Text labels consistency

### DIFF
--- a/aasrp/form.py
+++ b/aasrp/form.py
@@ -63,7 +63,8 @@ class AaSrpLinkForm(ModelForm):
         # empty_label=_("Please select a fleet type"),
     )
     fleet_doctrine = forms.CharField(
-        required=True, label=get_mandatory_form_label_text(_("Fleet Doctrine"))
+        required=True,
+        label=get_mandatory_form_label_text(_("Doctrine")),
     )
     aar_link = forms.CharField(required=False, label=_("After Action Report Link"))
 

--- a/aasrp/templates/aasrp/partials/request_srp/fleet-details.html
+++ b/aasrp/templates/aasrp/partials/request_srp/fleet-details.html
@@ -10,7 +10,7 @@
 
         <div class="panel-body">
             <ul class="list-unstyled">
-                <li><b>{% translate "Fleet name" %}:</b> {{ srp_link }}</li>
+                <li><b>{% translate "Fleet Name" %}:</b> {{ srp_link }}</li>
                 <li><b>{% translate "SRP Code" %}:</b> {{ srp_link.srp_code }}</li>
 
                 {% if srp_link.fleet_type %}

--- a/aasrp/templates/aasrp/partials/view_requests/overview.html
+++ b/aasrp/templates/aasrp/partials/view_requests/overview.html
@@ -28,7 +28,7 @@
             </div>
 
             <div class="panel-srp-request-overview-cell">
-                <dt>{% translate "Fleet Commander" %}</dt>
+                <dt>{% translate "Fleet Commander" %}:</dt>
                 <dd>{{ srp_link.fleet_commander }}</dd>
             </div>
 


### PR DESCRIPTION
Fixes missed colon.
Removes unque text labels, replaces with widely used ones (Fleet name, Fleet Doctrine).