### PR TITLE
[FIX] Pluralise warning text in modal

### DIFF
--- a/aasrp/templates/aasrp/modals/view_requests/mark_complete_modal.html
+++ b/aasrp/templates/aasrp/modals/view_requests/mark_complete_modal.html
@@ -24,9 +24,13 @@
 
                 {% if srp_link.pending_requests > 0 %}
                     <p class="alert alert-warning">
-                        {% blocktranslate with number_pending_requests=srp_link.pending_requests %}
+                        {% blocktranslate count number_pending_requests=srp_link.pending_requests %}
                             This SRP link still has {{ number_pending_requests }} pending
-                            SRP request(s). Are you absolutely certain you want to mark
+                            SRP request. Are you absolutely certain you want to mark
+                            this SRP link as completed?
+                        {% plural %}
+                            This SRP link still has {{ number_pending_requests }} pending
+                            SRP requests. Are you absolutely certain you want to mark
                             this SRP link as completed?
                         {% endblocktranslate %}
                     </p>


### PR DESCRIPTION
## Description

### Fixed

- Pluralise warning text in modal

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
