### PR TITLE
[FIX] Kill mail detection from zKillboard's API response.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,14 @@ Section Order:
 ### Security
 -->
 
+### Fixed
+
+- Kill mail detection from zKillboard's API response.\
+  Under certain circumstances,
+  the zKillboard API returns more than one kill mail in the response,
+  which caused an error in the SRP request form.
+  This has been fixed now.
+
 ## \[2.0.2\] - 2024-05-16
 
 ### Changed

--- a/aasrp/managers.py
+++ b/aasrp/managers.py
@@ -47,7 +47,7 @@ class SrpManager:
         return kill_id
 
     @staticmethod
-    def get_kill_data(kill_id: str):
+    def get_kill_data(kill_id: str):  # pylint: disable=too-many-locals
         """
         Get kill data from zKillboard
 
@@ -67,7 +67,7 @@ class SrpManager:
             error_str = str(exc)
 
             logger.warning(
-                msg=f"Unable to get killmail details from zKillboard. Error: {error_str}",
+                msg=f"Unable to get kill mail details from zKillboard. Error: {error_str}",
                 exc_info=True,
             )
 
@@ -79,7 +79,25 @@ class SrpManager:
 
             raise ValueError(error_str) from exc
 
-        result = request_result.json()[0]
+        result_killmails = request_result.json()
+        result = None
+        for killmail in result_killmails:
+            if killmail["killmail_id"] == int(kill_id):
+                result = killmail
+
+        if not result:
+            logger.warning(
+                msg=(
+                    "Couldn't find any kill mail information in zKillboard's API response. "
+                    "This is likely an issue with zKillboard."
+                ),
+                exc_info=True,
+            )
+
+            raise ValueError(
+                "Couldn't find any kill mail information in zKillboard's API response. "
+                "This is likely an issue with zKillboard."
+            )
 
         try:
             killmail_id = result["killmail_id"]

--- a/aasrp/views/general.py
+++ b/aasrp/views/general.py
@@ -319,7 +319,9 @@ def _save_srp_request(  # pylint: disable=too-many-arguments, too-many-locals
 
 @login_required
 @permission_required("aasrp.basic_access")
-def request_srp(request: WSGIRequest, srp_code: str) -> HttpResponse:
+def request_srp(  # pylint: disable=too-many-locals
+    request: WSGIRequest, srp_code: str
+) -> HttpResponse:
     """
     SRP request
 
@@ -386,7 +388,7 @@ def request_srp(request: WSGIRequest, srp_code: str) -> HttpResponse:
                 (ship_type_id, ship_value, victim_id) = SrpManager.get_kill_data(
                     kill_id=srp_kill_link_id
                 )
-            except ValueError:
+            except ValueError as err:
                 # Invalid killmail
                 logger.debug(
                     msg=(
@@ -396,9 +398,14 @@ def request_srp(request: WSGIRequest, srp_code: str) -> HttpResponse:
                     )
                 )
 
-                error_message_text = _(
-                    f"Your kill mail link ({submitted_killmail_link}) is invalid or the zKillboard API is not answering at the moment. Please make sure you are using either {ZKILLBOARD_BASE_URL} or {EVETOOLS_KILLBOARD_BASE_URL}"  # pylint: disable=line-too-long
-                )
+                if len(str(err)) > 0:
+                    error_message_text = _(
+                        f"Something went wrong, your kill mail ({submitted_killmail_link}) could not be parsed: {str(err)}"  # pylint: disable=line-too-long
+                    )
+                else:
+                    error_message_text = _(
+                        f"Your kill mail link ({submitted_killmail_link}) is invalid or the zKillboard API is not answering at the moment. Please make sure you are using either {ZKILLBOARD_BASE_URL} or {EVETOOLS_KILLBOARD_BASE_URL}"  # pylint: disable=line-too-long
+                    )
 
                 messages.error(request=request, message=error_message_text)
 


### PR DESCRIPTION
## Description

### Fixed

- Kill mail detection from zKillboard's API response.\
  Under certain circumstances,
  the zKillboard API returns more than one kill mail in the response,
  which caused an error in the SRP request form.
  This has been fixed now. (Bug reported to zKillboard)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
