### PR TITLE
[FIX] SRP request status translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ Section Order:
 ### Security
 -->
 
+### Fixed
+
+- SRP request status now shows its translated value in the SRP request detail modal
+
 ## \[2.1.0\] - 2024-06-13
 
 ### Added

--- a/aasrp/models.py
+++ b/aasrp/models.py
@@ -6,7 +6,7 @@ Our Models
 from django.contrib.auth.models import User
 from django.db import models
 from django.utils import timezone
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy as _
 
 # Alliance Auth
 from allianceauth.eveonline.models import EveCharacter

--- a/aasrp/views/ajax.py
+++ b/aasrp/views/ajax.py
@@ -340,7 +340,7 @@ def srp_link_view_requests_data(request: WSGIRequest, srp_code: str) -> JsonResp
                 "payout_amount": srp_request.payout_amount,
                 "request_status_icon": srp_request_status_icon,
                 "actions": srp_request_action_icons,
-                "request_status": srp_request.request_status,
+                "request_status": srp_request.get_request_status_display(),
             }
         )
 
@@ -428,7 +428,7 @@ def srp_request_additional_information(
         "character": character,
         "additional_info": additional_info,
         "request_status_banner_alert_level": request_status_banner_alert_level,
-        "request_status": srp_request.request_status,
+        "request_status": srp_request.get_request_status_display(),
         "insurance_information": insurance_information,
         "request_history": request_history,
     }


### PR DESCRIPTION
## Description

### Fixed

- SRP request status now shows its translated value in the SRP request detail modal

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
