### PR TITLE
[CHANGE] Show "View all/active" button only in SRP links view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ Section Order:
 ### Security
 -->
 
+### Changed
+
+- "View all/active" button now is only shown when in the SRP links view
+
 ## \[2.2.0\] - 2024-06-18
 
 ### Fixed

--- a/aasrp/templates/aasrp/partials/navigation/actions.html
+++ b/aasrp/templates/aasrp/partials/navigation/actions.html
@@ -1,17 +1,19 @@
 {% load i18n %}
 
 {% if perms.aasrp.manage_srp %}
-    <li class="nav-item">
-        {% if request.resolver_match.url_name == "srp_links_all" %}
-            <a href="{% url 'aasrp:srp_links' %}" class="nav-link py-0">
-                <span class="btn btn-secondary">{% translate "View active" %}</span>
-            </a>
-        {% else %}
-            <a href="{% url 'aasrp:srp_links_all' %}" class="nav-link py-0">
-                <span class="btn btn-secondary">{% translate "View all" %}</span>
-            </a>
-        {% endif %}
-    </li>
+    {% if request.resolver_match.url_name == "srp_links" or request.resolver_match.url_name == "srp_links_all" %}
+        <li class="nav-item">
+            {% if request.resolver_match.url_name == "srp_links_all" %}
+                <a href="{% url 'aasrp:srp_links' %}" class="nav-link py-0">
+                    <span class="btn btn-secondary">{% translate "View active" %}</span>
+                </a>
+            {% else %}
+                <a href="{% url 'aasrp:srp_links_all' %}" class="nav-link py-0">
+                    <span class="btn btn-secondary">{% translate "View all" %}</span>
+                </a>
+            {% endif %}
+        </li>
+    {% endif %}
 {% endif %}
 
 {% if perms.aasrp.create_srp or perms.aasrp.manage_srp %}


### PR DESCRIPTION
## Description

### Changed

- "View all/active" button now is only shown when in the SRP links view

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
