### PR TITLE
[ADD] EVE-KILL to the list of valid killboards for SRP requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ Section Order:
 ### Security
 -->
 
+### Added
+
+- [EVE-KILL](https://eve-kill.com/) to the list of valid killboards for posting kill mails in SRP requests
+
 ## \[2.3.1\] - 2024-08-11
 
 ### Added

--- a/aasrp/constants.py
+++ b/aasrp/constants.py
@@ -22,17 +22,25 @@ SRP_REQUEST_NOTIFICATION_INQUIRY_NOTE = _(
     "request code with your inquiry."
 )
 
-
-# zKillboard - https://zkillboard.com/
-ZKILLBOARD_BASE_URL = "https://zkillboard.com/"
-ZKILLBOARD_API_URL = "https://zkillboard.com/api/"
-ZKILLBOARD_BASE_URL_REGEX = r"^http[s]?:\/\/zkillboard\.com\/"
-ZKILLBOARD_KILLMAIL_URL_REGEX = r"^http[s]?:\/\/zkillboard\.com\/kill\/\d+\/"
-
-# EveTools Killboard - https://kb.evetools.org/
-EVETOOLS_KILLBOARD_BASE_URL = "https://kb.evetools.org/"
-EVETOOLS_KILLBOARD_BASE_URL_REGEX = r"^http[s]?:\/\/kb\.evetools\.org\/"
-EVETOOLS_KILLBOARD_KILLMAIL_URL_REGEX = r"^http[s]?:\/\/kb\.evetools\.org\/kill\/\d+"
+# Killboard URLs and regex
+KILLBOARD_DATA = {
+    "zKillboard": {
+        "base_url": "https://zkillboard.com/",
+        "api_url": "https://zkillboard.com/api/",
+        "base_url_regex": r"^http[s]?:\/\/zkillboard\.com\/",
+        "killmail_url_regex": r"^http[s]?:\/\/zkillboard\.com\/kill\/\d+\/",
+    },
+    "EveTools": {
+        "base_url": "https://kb.evetools.org/",
+        "base_url_regex": r"^http[s]?:\/\/kb\.evetools\.org\/",
+        "killmail_url_regex": r"^http[s]?:\/\/kb\.evetools\.org\/kill\/\d+",
+    },
+    "EVE-KILL": {
+        "base_url": "https://eve-kill.com/",
+        "base_url_regex": r"^http[s]?:\/\/eve-kill\.com\/",
+        "killmail_url_regex": r"^http[s]?:\/\/eve-kill\.com\/kill\/\d+",
+    },
+}
 
 
 # Embed colors

--- a/aasrp/form.py
+++ b/aasrp/form.py
@@ -22,8 +22,8 @@ evetools_base_url: str = KILLBOARD_DATA["EveTools"]["base_url"]
 eve_kill_base_url: str = KILLBOARD_DATA["EVE-KILL"]["base_url"]
 
 # Killboard regex
-zkilboard_base_url_regex: str = KILLBOARD_DATA["zKillboard"]["base_url_regex"]
-zkilboard_killmail_url_regex: str = KILLBOARD_DATA["zKillboard"]["killmail_url_regex"]
+zkillboard_base_url_regex: str = KILLBOARD_DATA["zKillboard"]["base_url_regex"]
+zkillboard_killmail_url_regex: str = KILLBOARD_DATA["zKillboard"]["killmail_url_regex"]
 evetools_base_url_regex: str = KILLBOARD_DATA["EveTools"]["base_url_regex"]
 evetools_killmail_url_regex: str = KILLBOARD_DATA["EveTools"]["killmail_url_regex"]
 eve_kill_base_url_regex: str = KILLBOARD_DATA["EVE-KILL"]["base_url_regex"]
@@ -147,7 +147,7 @@ class SrpRequestForm(ModelForm):
         if not any(
             re.match(pattern=regex, string=killboard_link)
             for regex in [
-                zkilboard_base_url_regex,
+                zkillboard_base_url_regex,
                 evetools_base_url_regex,
                 eve_kill_base_url_regex,
             ]
@@ -162,7 +162,7 @@ class SrpRequestForm(ModelForm):
         if not any(
             re.match(pattern=regex, string=killboard_link)
             for regex in [
-                zkilboard_killmail_url_regex,
+                zkillboard_killmail_url_regex,
                 evetools_killmail_url_regex,
                 eve_kill_killmail_url_regex,
             ]

--- a/aasrp/form.py
+++ b/aasrp/form.py
@@ -12,16 +12,22 @@ from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
 
 # AA SRP
-from aasrp.constants import (
-    EVETOOLS_KILLBOARD_BASE_URL,
-    EVETOOLS_KILLBOARD_BASE_URL_REGEX,
-    EVETOOLS_KILLBOARD_KILLMAIL_URL_REGEX,
-    ZKILLBOARD_BASE_URL,
-    ZKILLBOARD_BASE_URL_REGEX,
-    ZKILLBOARD_KILLMAIL_URL_REGEX,
-)
+from aasrp.constants import KILLBOARD_DATA
 from aasrp.managers import SrpManager
 from aasrp.models import FleetType, Setting, SrpLink, SrpRequest, UserSetting
+
+# Killboard URLs
+zkilboard_base_url: str = KILLBOARD_DATA["zKillboard"]["base_url"]
+evetools_base_url: str = KILLBOARD_DATA["EveTools"]["base_url"]
+eve_kill_base_url: str = KILLBOARD_DATA["EVE-KILL"]["base_url"]
+
+# Killboard regex
+zkilboard_base_url_regex: str = KILLBOARD_DATA["zKillboard"]["base_url_regex"]
+zkilboard_killmail_url_regex: str = KILLBOARD_DATA["zKillboard"]["killmail_url_regex"]
+evetools_base_url_regex: str = KILLBOARD_DATA["EveTools"]["base_url_regex"]
+evetools_killmail_url_regex: str = KILLBOARD_DATA["EveTools"]["killmail_url_regex"]
+eve_kill_base_url_regex: str = KILLBOARD_DATA["EVE-KILL"]["base_url_regex"]
+eve_kill_killmail_url_regex: str = KILLBOARD_DATA["EVE-KILL"]["killmail_url_regex"]
 
 
 def get_mandatory_form_label_text(text: str) -> str:
@@ -104,7 +110,7 @@ class SrpRequestForm(ModelForm):
         max_length=254,
         required=True,
         help_text=_(
-            f"Find your kill mail on {ZKILLBOARD_BASE_URL} or {EVETOOLS_KILLBOARD_BASE_URL} and paste the link here."  # pylint: disable=line-too-long
+            f"Find your kill mail on {zkilboard_base_url},  {evetools_base_url} or {eve_kill_base_url} and paste the link here."  # pylint: disable=line-too-long
         ),
     )
 
@@ -140,11 +146,15 @@ class SrpRequestForm(ModelForm):
         # Check if it's a link from one of the accepted kill boards
         if not any(
             re.match(pattern=regex, string=killboard_link)
-            for regex in [ZKILLBOARD_BASE_URL_REGEX, EVETOOLS_KILLBOARD_BASE_URL_REGEX]
+            for regex in [
+                zkilboard_base_url_regex,
+                evetools_base_url_regex,
+                eve_kill_base_url_regex,
+            ]
         ):
             raise forms.ValidationError(
                 message=_(
-                    f"Invalid link. Please use {ZKILLBOARD_BASE_URL} or {EVETOOLS_KILLBOARD_BASE_URL}"  # pylint: disable=line-too-long
+                    f"Invalid link. Please use {zkilboard_base_url}, {evetools_base_url} or {eve_kill_base_url}"  # pylint: disable=line-too-long
                 )
             )
 
@@ -152,8 +162,9 @@ class SrpRequestForm(ModelForm):
         if not any(
             re.match(pattern=regex, string=killboard_link)
             for regex in [
-                ZKILLBOARD_KILLMAIL_URL_REGEX,
-                EVETOOLS_KILLBOARD_KILLMAIL_URL_REGEX,
+                zkilboard_killmail_url_regex,
+                evetools_killmail_url_regex,
+                eve_kill_killmail_url_regex,
             ]
         ):
             raise forms.ValidationError(

--- a/aasrp/managers.py
+++ b/aasrp/managers.py
@@ -19,7 +19,7 @@ from app_utils.logging import LoggerAddTag
 
 # AA SRP
 from aasrp import __title__
-from aasrp.constants import USERAGENT, ZKILLBOARD_API_URL
+from aasrp.constants import KILLBOARD_DATA, USERAGENT
 from aasrp.providers import esi
 
 logger = LoggerAddTag(get_extension_logger(__name__), __title__)
@@ -57,7 +57,8 @@ class SrpManager:
         :rtype:
         """
 
-        url = f"{ZKILLBOARD_API_URL}killID/{kill_id}/"
+        zkillboard_api_url = KILLBOARD_DATA["zKillboard"]["api_url"]
+        url = f"{zkillboard_api_url}killID/{kill_id}/"
         headers = {"User-Agent": USERAGENT, "Content-Type": "application/json"}
         request_result = requests.get(url=url, headers=headers, timeout=5)
 

--- a/aasrp/views/general.py
+++ b/aasrp/views/general.py
@@ -440,10 +440,11 @@ def request_srp(  # pylint: disable=too-many-locals
                         f"Something went wrong, your kill mail ({submitted_killmail_link}) could not be parsed: {str(err)}"  # pylint: disable=line-too-long
                     )
                 else:
-                    zkillboard_base_url = KILLBOARD_DATA["zKillboard"]["base_url"]
-                    evetools_killboard_base_url = KILLBOARD_DATA["EveTools"]["base_url"]
+                    zkillboard_base_url: str = KILLBOARD_DATA["zKillboard"]["base_url"]
+                    evetools_base_url: str = KILLBOARD_DATA["EveTools"]["base_url"]
+                    eve_kill_base_url: str = KILLBOARD_DATA["EVE-KILL"]["base_url"]
                     error_message_text = _(
-                        f"Your kill mail link ({submitted_killmail_link}) is invalid or the zKillboard API is not answering at the moment. Please make sure you are using either {zkillboard_base_url} or {evetools_killboard_base_url}"  # pylint: disable=line-too-long
+                        f"Your kill mail link ({submitted_killmail_link}) is invalid or the zKillboard API is not answering at the moment. Please make sure you are using either {zkillboard_base_url}, {evetools_base_url} or {eve_kill_base_url}"  # pylint: disable=line-too-long
                     )
 
                 messages.error(request=request, message=error_message_text)

--- a/aasrp/views/general.py
+++ b/aasrp/views/general.py
@@ -23,7 +23,7 @@ from eveuniverse.models import EveType
 
 # AA SRP
 from aasrp import __title__
-from aasrp.constants import EVETOOLS_KILLBOARD_BASE_URL, ZKILLBOARD_BASE_URL
+from aasrp.constants import KILLBOARD_DATA
 from aasrp.form import (
     SrpLinkForm,
     SrpLinkUpdateForm,
@@ -440,8 +440,10 @@ def request_srp(  # pylint: disable=too-many-locals
                         f"Something went wrong, your kill mail ({submitted_killmail_link}) could not be parsed: {str(err)}"  # pylint: disable=line-too-long
                     )
                 else:
+                    zkillboard_base_url = KILLBOARD_DATA["zKillboard"]["base_url"]
+                    evetools_killboard_base_url = KILLBOARD_DATA["EveTools"]["base_url"]
                     error_message_text = _(
-                        f"Your kill mail link ({submitted_killmail_link}) is invalid or the zKillboard API is not answering at the moment. Please make sure you are using either {ZKILLBOARD_BASE_URL} or {EVETOOLS_KILLBOARD_BASE_URL}"  # pylint: disable=line-too-long
+                        f"Your kill mail link ({submitted_killmail_link}) is invalid or the zKillboard API is not answering at the moment. Please make sure you are using either {zkillboard_base_url} or {evetools_killboard_base_url}"  # pylint: disable=line-too-long
                     )
 
                 messages.error(request=request, message=error_message_text)


### PR DESCRIPTION
## Description

### Added

- [EVE-KILL](https://eve-kill.com/) to the list of valid killboards for posting kill mails in SRP requests

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
