### PR TITLE
[FIX] Translation string escape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ Section Order:
 ### Security
 -->
 
+### Fixed
+
+- Escaping translation strings to fix potential issues with French and Italian translations
+
 ### Changed
 
 - Set user agent according to MDN guidelines

--- a/aasrp/locale/django.pot
+++ b/aasrp/locale/django.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: AA SRP 2.5.3\n"
+"Project-Id-Version: AA SRP 2.5.4\n"
 "Report-Msgid-Bugs-To: https://github.com/ppfeufer/aa-srp/issues\n"
-"POT-Creation-Date: 2024-12-14 18:56+0100\n"
+"POT-Creation-Date: 2025-01-13 15:03+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -37,8 +37,8 @@ msgstr ""
 #: aasrp/admin.py:140
 #: aasrp/templates/aasrp/ajax-render/srp-request-additional-information.html:15
 #: aasrp/templates/aasrp/partials/view-requests/requests.html:16
-#: aasrp/templates/aasrp/view-own-requests.html:44
-#: aasrp/templates/aasrp/view-requests.html:53
+#: aasrp/templates/aasrp/view-own-requests.html:26
+#: aasrp/templates/aasrp/view-requests.html:37
 msgid "Requestor"
 msgstr ""
 
@@ -94,7 +94,7 @@ msgstr[1] ""
 msgid "AA Ship Replacement v{__version__}"
 msgstr ""
 
-#: aasrp/constants.py:20
+#: aasrp/constants.py:26
 msgid ""
 "If you have any questions regarding your SRP request, feel free to contact "
 "your request reviser.\n"
@@ -153,8 +153,8 @@ msgstr ""
 
 #: aasrp/form.py:138 aasrp/form.py:147 aasrp/models.py:307 aasrp/models.py:401
 #: aasrp/templates/aasrp/ajax-render/srp-request-additional-information.html:82
-#: aasrp/templates/aasrp/view-own-requests.html:47
-#: aasrp/templates/aasrp/view-requests.html:57
+#: aasrp/templates/aasrp/view-own-requests.html:27
+#: aasrp/templates/aasrp/view-requests.html:39
 msgid "Additional information"
 msgstr ""
 
@@ -321,11 +321,11 @@ msgstr ""
 msgid "SRP status"
 msgstr ""
 
-#: aasrp/models.py:120 aasrp/templates/aasrp/dashboard.html:47
+#: aasrp/models.py:120 aasrp/templates/aasrp/dashboard.html:25
 #: aasrp/templates/aasrp/partials/dashboard/srp-links.html:23
 #: aasrp/templates/aasrp/partials/request-srp/fleet-details.html:14
 #: aasrp/templates/aasrp/partials/view-requests/overview.html:50
-#: aasrp/templates/aasrp/view-own-requests.html:37
+#: aasrp/templates/aasrp/view-own-requests.html:24
 msgid "SRP code"
 msgstr ""
 
@@ -370,9 +370,9 @@ msgstr ""
 msgid "Rejected"
 msgstr ""
 
-#: aasrp/models.py:271 aasrp/templates/aasrp/dashboard.html:48
+#: aasrp/models.py:271 aasrp/templates/aasrp/dashboard.html:26
 #: aasrp/templates/aasrp/partials/view-requests/requests.html:18
-#: aasrp/templates/aasrp/view-own-requests.html:38
+#: aasrp/templates/aasrp/view-own-requests.html:25
 msgid "Request code"
 msgstr ""
 
@@ -382,13 +382,11 @@ msgstr ""
 
 #: aasrp/models.py:289
 #: aasrp/templates/aasrp/ajax-render/srp-request-additional-information.html:27
-#: aasrp/templates/aasrp/dashboard.html:43
+#: aasrp/templates/aasrp/dashboard.html:24
 #: aasrp/templates/aasrp/partials/view-own-requests/user-srp-requests.html:18
 #: aasrp/templates/aasrp/partials/view-requests/requests.html:17
-#: aasrp/templates/aasrp/view-own-requests.html:33
-#: aasrp/templates/aasrp/view-own-requests.html:45
-#: aasrp/templates/aasrp/view-requests.html:45
-#: aasrp/templates/aasrp/view-requests.html:54
+#: aasrp/templates/aasrp/view-own-requests.html:23
+#: aasrp/templates/aasrp/view-requests.html:32
 msgid "Character"
 msgstr ""
 
@@ -396,9 +394,9 @@ msgstr ""
 msgid "Ship type"
 msgstr ""
 
-#: aasrp/models.py:313 aasrp/templates/aasrp/dashboard.html:42
-#: aasrp/templates/aasrp/view-own-requests.html:32
-#: aasrp/templates/aasrp/view-requests.html:43
+#: aasrp/models.py:313 aasrp/templates/aasrp/dashboard.html:23
+#: aasrp/templates/aasrp/view-own-requests.html:22
+#: aasrp/templates/aasrp/view-requests.html:30
 msgid "Request status"
 msgstr ""
 
@@ -445,7 +443,7 @@ msgstr ""
 
 #: aasrp/models.py:377
 #: aasrp/templates/aasrp/ajax-render/srp-request-additional-information.html:58
-#: aasrp/templates/aasrp/view-requests.html:56
+#: aasrp/templates/aasrp/view-requests.html:38
 msgid "Insurance payout"
 msgstr ""
 
@@ -540,13 +538,11 @@ msgid "SRP request status"
 msgstr ""
 
 #: aasrp/templates/aasrp/ajax-render/srp-request-additional-information.html:41
-#: aasrp/templates/aasrp/dashboard.html:41
+#: aasrp/templates/aasrp/dashboard.html:22
 #: aasrp/templates/aasrp/partials/view-own-requests/user-srp-requests.html:20
 #: aasrp/templates/aasrp/partials/view-requests/requests.html:19
-#: aasrp/templates/aasrp/view-own-requests.html:31
-#: aasrp/templates/aasrp/view-own-requests.html:46
-#: aasrp/templates/aasrp/view-requests.html:44
-#: aasrp/templates/aasrp/view-requests.html:55
+#: aasrp/templates/aasrp/view-own-requests.html:21
+#: aasrp/templates/aasrp/view-requests.html:31
 msgid "Ship"
 msgstr ""
 
@@ -566,83 +562,83 @@ msgstr ""
 msgid "SRP request status has changed to"
 msgstr ""
 
-#: aasrp/templates/aasrp/base.html:35
+#: aasrp/templates/aasrp/base.html:28
 msgctxt "Decimal separator"
 msgid "."
 msgstr ""
 
-#: aasrp/templates/aasrp/base.html:36
+#: aasrp/templates/aasrp/base.html:29
 msgctxt "Thousands separator"
 msgid ","
 msgstr ""
 
-#: aasrp/templates/aasrp/base.html:37
+#: aasrp/templates/aasrp/base.html:30
 msgid "No data available in this table"
 msgstr ""
 
-#: aasrp/templates/aasrp/base.html:38
+#: aasrp/templates/aasrp/base.html:31
 msgctxt "Keep _END_ as it is. It will be replaced by a number."
 msgid "Showing _END_ entries"
 msgstr ""
 
-#: aasrp/templates/aasrp/base.html:39
+#: aasrp/templates/aasrp/base.html:32
 msgctxt "Keep _MAX_ as it is. It will be replaced by a number."
 msgid "(filtered from _MAX_ total entries)"
 msgstr ""
 
-#: aasrp/templates/aasrp/base.html:40
+#: aasrp/templates/aasrp/base.html:33
 msgid "No records available"
 msgstr ""
 
-#: aasrp/templates/aasrp/base.html:43
+#: aasrp/templates/aasrp/base.html:34
 msgid "Loading …"
 msgstr ""
 
-#: aasrp/templates/aasrp/base.html:44
+#: aasrp/templates/aasrp/base.html:35
 msgid "Processing …"
 msgstr ""
 
-#: aasrp/templates/aasrp/base.html:45
+#: aasrp/templates/aasrp/base.html:36
 msgid "Nothing found, sorry …"
 msgstr ""
 
-#: aasrp/templates/aasrp/base.html:47
+#: aasrp/templates/aasrp/base.html:37
 msgid "Search …"
 msgstr ""
 
-#: aasrp/templates/aasrp/base.html:49
+#: aasrp/templates/aasrp/base.html:38
 msgid "First"
 msgstr ""
 
-#: aasrp/templates/aasrp/base.html:50
+#: aasrp/templates/aasrp/base.html:39
 msgid "Last"
 msgstr ""
 
-#: aasrp/templates/aasrp/base.html:51
+#: aasrp/templates/aasrp/base.html:40
 msgid "Next"
 msgstr ""
 
-#: aasrp/templates/aasrp/base.html:52
+#: aasrp/templates/aasrp/base.html:41
 msgid "Previous"
 msgstr ""
 
-#: aasrp/templates/aasrp/base.html:55
+#: aasrp/templates/aasrp/base.html:42
 msgid ": activate to sort column ascending"
 msgstr ""
 
-#: aasrp/templates/aasrp/base.html:56
+#: aasrp/templates/aasrp/base.html:43
 msgid ": activate to sort column descending"
 msgstr ""
 
-#: aasrp/templates/aasrp/dashboard.html:53
+#: aasrp/templates/aasrp/dashboard.html:27
 msgid "Are you sure you want to (re-)activate the following SRP link?"
 msgstr ""
 
-#: aasrp/templates/aasrp/dashboard.html:56
+#: aasrp/templates/aasrp/dashboard.html:28
 msgid "Are you sure you want to disable the following SRP link?"
 msgstr ""
 
-#: aasrp/templates/aasrp/dashboard.html:59
+#: aasrp/templates/aasrp/dashboard.html:29
 msgid ""
 "Are you sure you want to delete the following SRP link and all SRP requests "
 "tied to it?"
@@ -906,24 +902,24 @@ msgstr ""
 msgid "Click on the value to edit, Enter to save, ESC to cancel."
 msgstr ""
 
-#: aasrp/templates/aasrp/view-own-requests.html:48
-#: aasrp/templates/aasrp/view-requests.html:58
+#: aasrp/templates/aasrp/view-own-requests.html:28
+#: aasrp/templates/aasrp/view-requests.html:40
 msgid "Reject information"
 msgstr ""
 
-#: aasrp/templates/aasrp/view-requests.html:47
+#: aasrp/templates/aasrp/view-requests.html:33
 msgid "Click here to change the payout amount for this SRP request."
 msgstr ""
 
-#: aasrp/templates/aasrp/view-requests.html:48
+#: aasrp/templates/aasrp/view-requests.html:34
 msgid "Enter SRP payout value"
 msgstr ""
 
-#: aasrp/templates/aasrp/view-requests.html:49
+#: aasrp/templates/aasrp/view-requests.html:35
 msgid "Empty values are not allowed"
 msgstr ""
 
-#: aasrp/templates/aasrp/view-requests.html:63
+#: aasrp/templates/aasrp/view-requests.html:36
 msgid "This field is required."
 msgstr ""
 

--- a/aasrp/templates/aasrp/base.html
+++ b/aasrp/templates/aasrp/base.html
@@ -25,6 +25,23 @@
         </div>
 
         <div class="aa-srp-body">
+            {% translate "." context "Decimal separator" as decimalSeparator %}
+            {% translate "," context "Thousands separator" as thousandsSeparator %}
+            {% translate "No data available in this table" as emptyTable %}
+            {% translate "Showing _END_ entries" as info context "Keep _END_ as it is. It will be replaced by a number." %}
+            {% translate "(filtered from _MAX_ total entries)" as infoFiltered context "Keep _MAX_ as it is. It will be replaced by a number." %}
+            {% translate "No records available" as infoEmpty %}
+            {% translate "Loading …" as loadingRecords %}
+            {% translate "Processing …" as processing %}
+            {% translate "Nothing found, sorry …" as zeroRecords%}
+            {% translate "Search …" as searchPaceholder %}
+            {% translate "First" as paginateFirst %}
+            {% translate "Last" as paginateLast %}
+            {% translate "Next" as paginateNext %}
+            {% translate "Previous" as paginatePrevious %}
+            {% translate ": activate to sort column ascending" as ariaSortAscending %}
+            {% translate ": activate to sort column descending" as ariaSortDescending %}
+
             <script>
                 const aaSrpJsSettingsDefaults = {
                     datetimeFormat: 'YYYY-MM-DD<br>HH:mm',
@@ -32,31 +49,31 @@
                     dataTable: {
                         paging: true,
                         translation: {
-                            decimal: '{% translate "." context "Decimal separator" %}',
-                            thousands: '{% translate "," context "Thousands separator" %}',
-                            emptyTable: '{% translate "No data available in this table" %}',
-                            info: '{% translate "Showing _END_ entries" context "Keep _END_ as it is. It will be replaced by a number." %}',
-                            infoFiltered: '{% translate "(filtered from _MAX_ total entries)" context "Keep _MAX_ as it is. It will be replaced by a number." %}',
-                            infoEmpty: '{% translate "No records available" %}',
+                            decimal: '{{ decimalSeparator|escapejs }}',
+                            thousands: '{{ thousandsSeparator|escapejs }}',
+                            emptyTable: '{{ emptyTable|escapejs }}',
+                            info: '{{ info|escapejs }}',
+                            infoFiltered: '{{ infoFiltered|escapejs }}',
+                            infoEmpty: '{{ infoEmpty|escapejs }}',
                             infoPostFix: '',
                             lengthMenu: '_MENU_',
-                            loadingRecords: '{% translate "Loading …" %}',
-                            processing: '{% translate "Processing …" %}',
-                            zeroRecords: '{% translate "Nothing found, sorry …" %}',
+                            loadingRecords: '{{ loadingRecords|escapejs }}',
+                            processing: '{{ processing|escapejs }}',
+                            zeroRecords: '{{ zeroRecords|escapejs }}',
                             search: '_INPUT_',
-                            searchPlaceholder: '{% translate "Search …" %}',
+                            searchPlaceholder: '{{ searchPaceholder|escapejs }}',
                             paginate: {
-                                first: '{% translate "First" %}',
-                                last: '{% translate "Last" %}',
-                                next: '{% translate "Next" %}',
-                                previous: '{% translate "Previous" %}'
+                                first: '{{ paginateFirst|escapejs }}',
+                                last: '{{ paginateLast|escapejs }}',
+                                next: '{{ paginateNext|escapejs }}',
+                                previous: '{{ paginatePrevious|escapejs }}'
                             },
                             aria: {
-                                sortAscending: '{% translate ": activate to sort column ascending" %}',
-                                sortDescending: '{% translate ": activate to sort column descending" %}'
+                                sortAscending: '{{ ariaSortAscending|escapejs }}',
+                                sortDescending: '{{ ariaSortDescending|escapejs }}'
                             }
                         }
-                    },
+                    }
                 };
             </script>
 

--- a/aasrp/templates/aasrp/dashboard.html
+++ b/aasrp/templates/aasrp/dashboard.html
@@ -19,6 +19,15 @@
 {% endblock %}
 
 {% block extra_javascript %}
+    {% translate "Ship" as translateShip %}
+    {% translate "Request status" as translateRequestStatus %}
+    {% translate "Character" as translateCharacter %}
+    {% translate "SRP code" as translateSrpCode %}
+    {% translate "Request code" as translateRequestCode %}
+    {% translate "Are you sure you want to (re-)activate the following SRP link?" as translateEnableSrpLink %}
+    {% translate "Are you sure you want to disable the following SRP link?" as translateDisableSrpLink %}
+    {% translate "Are you sure you want to delete the following SRP link and all SRP requests tied to it?" as translateDeleteSrpLink %}
+
     <script>
         /**
          * Passing some setting to our JS
@@ -38,25 +47,25 @@
             },
             translation: {
                 filter: {
-                    ship: '{% translate "Ship" %}',
-                    requestStatus: '{% translate "Request status" %}',
-                    character: '{% translate "Character" %}',
+                    ship: '{{ translateShip|escapejs }}',
+                    requestStatus: '{{ translateRequestStatus|escapejs }}',
+                    character: '{{ translateCharacter|escapejs }}',
                 },
                 dataTable: {
                     content: {
-                        srpCode: '{% translate "SRP code" %}',
-                        requestCode: '{% translate "Request code" %}'
+                        srpCode: '{{ translateSrpCode|escapejs }}',
+                        requestCode: '{{ translateRequestCode|escapejs }}',
                     }
                 },
                 modal: {
                     enableSrpLink: {
-                        body: '<p>{% translate "Are you sure you want to (re-)activate the following SRP link?" %}</p>'
+                        body: '<p>{{ translateEnableSrpLink|escapejs }}</p>'
                     },
                     disableSrpLink: {
-                        body: '<p>{% translate "Are you sure you want to disable the following SRP link?" %}</p>'
+                        body: '<p>{{ translateDisableSrpLink|escapejs }}</p>'
                     },
                     deleteSrpLink: {
-                        body: '<p>{% translate "Are you sure you want to delete the following SRP link and all SRP requests tied to it?" %}</p>'
+                        body: '<p>{{ translateDeleteSrpLink|escapejs }}</p>'
                     },
                 }
             }

--- a/aasrp/templates/aasrp/view-own-requests.html
+++ b/aasrp/templates/aasrp/view-own-requests.html
@@ -18,6 +18,15 @@
 {% endblock %}
 
 {% block extra_javascript %}
+    {% translate "Ship" as translationShip %}
+    {% translate "Request status" as translationRequestStatus %}
+    {% translate "Character" as translationCharacter %}
+    {% translate "SRP code" as translationSrpCode %}
+    {% translate "Request code" as translationRequestCode %}
+    {% translate "Requestor" as translationRequestor %}
+    {% translate "Additional information" as translationAdditionalInformation %}
+    {% translate "Reject information" as translationRejectInformation %}
+
     <script>
         /**
          * Passing some setting to our JS
@@ -28,24 +37,24 @@
             },
             translation: {
                 filter: {
-                    ship: '{% translate "Ship" %}',
-                    requestStatus: '{% translate "Request status" %}',
-                    character: '{% translate "Character" %}',
+                    ship: '{{ translationShip|escapejs }}',
+                    requestStatus: '{{ translationRequestStatus|escapejs }}',
+                    character: '{{ translationCharacter|escapejs }}',
                 },
                 dataTable: {
                     content: {
-                        srpCode: '{% translate "SRP code" %}',
-                        requestCode: '{% translate "Request code" %}'
+                        srpCode: '{{ translationSrpCode|escapejs }}',
+                        requestCode: '{{ translationRequestCode|escapejs }}',
                     }
                 },
                 modal: {
                     srpDetails: {
                         body: {
-                            requestor: '{% translate "Requestor" %}',
-                            character: '{% translate "Character" %}',
-                            ship: '{% translate "Ship" %}',
-                            additionalInformation: '{% translate "Additional information" %}',
-                            rejectInformation: '{% translate "Reject information" %}'
+                            requestor: '{{ translationRequestor|escapejs }}',
+                            character: '{{ translationCharacter|escapejs }}',
+                            ship: '{{ translationShip|escapejs }}',
+                            additionalInformation: '{{ translationAdditionalInformation|escapejs }}',
+                            rejectInformation: '{{ translationRejectInformation|escapejs }}',
                         }
                     }
                 }

--- a/aasrp/templates/aasrp/view-requests.html
+++ b/aasrp/templates/aasrp/view-requests.html
@@ -27,6 +27,18 @@
 {% endblock %}
 
 {% block extra_javascript %}
+    {% translate "Request status" as translateRequestStatus %}
+    {% translate "Ship" as translateShip %}
+    {% translate "Character" as translateCharacter %}
+    {% translate "Click here to change the payout amount for this SRP request." as translateChangeSrpPayoutAmount %}
+    {% translate "Enter SRP payout value" as translateChangeSrpPayoutHeader %}
+    {% translate "Empty values are not allowed" as translateEditableValidate %}
+    {% translate "This field is required." as translateFieldRequired %}
+    {% translate "Requestor" as translateRequestor %}
+    {% translate "Insurance payout" as translateInsurancePayout %}
+    {% translate "Additional information" as translateAdditionalInformation %}
+    {% translate "Reject information" as translateRejectInformation %}
+
     <script>
         /**
          * passing some settings to our JS
@@ -40,27 +52,27 @@
             },
             translation: {
                 filter: {
-                    requestStatus: '{% translate "Request status" %}',
-                    ship: '{% translate "Ship" %}',
-                    character: '{% translate "Character" %}'
+                    requestStatus: '{{ translateRequestStatus|escapejs }}',
+                    ship: '{{ translateShip|escapejs }}',
+                    character: '{{ translateCharacter|escapejs }}'
                 },
-                changeSrpPayoutAmount: '{% translate "Click here to change the payout amount for this SRP request." %}',
-                changeSrpPayoutHeader: '{% translate "Enter SRP payout value" %}',
-                editableValidate: '{% translate "Empty values are not allowed" %}',
+                changeSrpPayoutAmount: '{{ translateChangeSrpPayoutAmount|escapejs }}',
+                changeSrpPayoutHeader: '{{ translateChangeSrpPayoutHeader|escapejs }}',
+                editableValidate: '{{ translateEditableValidate|escapejs }}',
                 modal: {
                     srpDetails: {
                         body: {
-                            requestor: '{% translate "Requestor" %}',
-                            character: '{% translate "Character" %}',
-                            ship: '{% translate "Ship" %}',
-                            insurance: '{% translate "Insurance payout" %}',
-                            additionalInformation: '{% translate "Additional information" %}',
-                            rejectInformation: '{% translate "Reject information" %}'
+                            requestor: '{{ translateRequestor|escapejs }}',
+                            character: '{{ translateCharacter|escapejs }}',
+                            ship: '{{ translateShip|escapejs }}',
+                            insurance: '{{ translateInsurancePayout|escapejs }}',
+                            additionalInformation: '{{ translateAdditionalInformation|escapejs }}',
+                            rejectInformation: '{{ translateRejectInformation|escapejs }}'
                         }
                     },
                     form: {
                         error: {
-                            fieldRequired: '{% translate "This field is required." %}'
+                            fieldRequired: '{{ translateFieldRequired|escapejs }}'
                         }
                     }
                 }


### PR DESCRIPTION
## Description

### Fixed

- Escaping translation strings to fix potential issues with French and Italian translations

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
