### PR TITLE
[CHANGE] Use `django-sri` for sri hashes

### DIFF
--- a/.make/conf.d/django.mk
+++ b/.make/conf.d/django.mk
@@ -5,9 +5,12 @@
 pot:
 	@echo "Creating or updating .pot file …"
 	@django-admin makemessages \
-		-l en \
+		--locale en \
 		--keep-pot \
-		--ignore 'build/*'
+		--ignore 'build/*' \
+		--ignore 'node_modules/*' \
+		--ignore 'testauth/*' \
+		--ignore 'runtests.py'
 	@current_app_version=$$(pip show $(appname) | grep 'Version: ' | awk '{print $$NF}'); \
 	sed -i "/\"Project-Id-Version: /c\\\"Project-Id-Version: $(appname_verbose) $$current_app_version\\\n\"" $(translation_template); \
 	sed -i "/\"Report-Msgid-Bugs-To: /c\\\"Report-Msgid-Bugs-To: $(git_repository_issues)\\\n\"" $(translation_template);
@@ -18,9 +21,12 @@ add_translation:
 	@echo "Adding a new translation"
 	@read -p "Enter the language code (e.g. 'en_GB'): " language_code; \
 	django-admin makemessages \
-		-l $$language_code \
+		--locale $$language_code \
 		--keep-pot \
-		--ignore 'build/*'; \
+		--ignore 'build/*' \
+		--ignore 'node_modules/*' \
+		--ignore 'testauth/*' \
+		--ignore 'runtests.py'; \
 	current_app_version=$$(pip show $(appname) | grep 'Version: ' | awk '{print $$NF}'); \
 	sed -i "/\"Project-Id-Version: /c\\\"Project-Id-Version: $(appname_verbose) $$current_app_version\\\n\"" $(translation_template); \
 	sed -i "/\"Report-Msgid-Bugs-To: /c\\\"Report-Msgid-Bugs-To: $(git_repository_issues)\\\n\"" $(translation_template); \
@@ -34,21 +40,24 @@ add_translation:
 translations:
 	@echo "Creating or updating translation files"
 	@django-admin makemessages \
-		-l cs_CZ \
-		-l de \
-		-l es \
-		-l fr_FR \
-		-l it_IT \
-		-l ja \
-		-l ko_KR \
-		-l nl_NL \
-		-l pl_PL \
-		-l ru \
-		-l sk \
-		-l uk \
-		-l zh_Hans \
+		--locale cs_CZ \
+		--locale de \
+		--locale es \
+		--locale fr_FR \
+		--locale it_IT \
+		--locale ja \
+		--locale ko_KR \
+		--locale nl_NL \
+		--locale pl_PL \
+		--locale ru \
+		--locale sk \
+		--locale uk \
+		--locale zh_Hans \
 		--keep-pot \
-		--ignore 'build/*'
+		--ignore 'build/*' \
+		--ignore 'node_modules/*' \
+		--ignore 'testauth/*' \
+		--ignore 'runtests.py'
 	@current_app_version=$$(pip show $(appname) | grep 'Version: ' | awk '{print $$NF}'); \
 	sed -i "/\"Project-Id-Version: /c\\\"Project-Id-Version: $(appname_verbose) $$current_app_version\\\n\"" $(translation_template); \
 	sed -i "/\"Report-Msgid-Bugs-To: /c\\\"Report-Msgid-Bugs-To: $(git_repository_issues)\\\n\"" $(translation_template); \
@@ -69,19 +78,19 @@ translations:
 compile_translations:
 	@echo "Compiling translation files"
 	@django-admin compilemessages \
-		-l cs_CZ \
-		-l de \
-		-l es \
-		-l fr_FR \
-		-l it_IT \
-		-l ja \
-		-l ko_KR \
-		-l nl_NL \
-		-l pl_PL \
-		-l ru \
-		-l sk \
-		-l uk \
-		-l zh_Hans
+		--locale cs_CZ \
+		--locale de \
+		--locale es \
+		--locale fr_FR \
+		--locale it_IT \
+		--locale ja \
+		--locale ko_KR \
+		--locale nl_NL \
+		--locale pl_PL \
+		--locale ru \
+		--locale sk \
+		--locale uk \
+		--locale zh_Hans
 
 # Migrate all database changes
 .PHONY: migrate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,12 @@ Section Order:
 ### Security
 -->
 
+### Changed
+
+- Use `django-sri` for sri hashes
+- Minimum requirements
+  - Alliance Auth >= 4.6.0
+
 ## [2.5.5] - 2025-01-13
 
 ### Fixed

--- a/aasrp/constants.py
+++ b/aasrp/constants.py
@@ -2,6 +2,9 @@
 Constants
 """
 
+# Standard Library
+import os
+
 # Third Party
 from requests.__version__ import __version__ as requests_version
 
@@ -20,6 +23,11 @@ USER_AGENT_ESI = f"{APP_NAME}/{__version__} +{GITHUB_URL} via django-esi/{esi_ve
 USER_AGENT_REQUESTS = (
     f"{APP_NAME}/{__version__} +{GITHUB_URL} via requests/{requests_version}"
 )
+
+# aa-srp/aasrp
+AA_SRP_BASE_DIR = os.path.join(os.path.dirname(__file__))
+# aa-srp/aasrp/static/aasrp
+AA_SRP_STATIC_DIR = os.path.join(AA_SRP_BASE_DIR, "static", "aasrp")
 
 
 SRP_REQUEST_NOTIFICATION_INQUIRY_NOTE = _(

--- a/aasrp/helper/static_files.py
+++ b/aasrp/helper/static_files.py
@@ -1,0 +1,41 @@
+"""
+Helper functions for static integrity calculations
+"""
+
+# Standard Library
+import os
+from pathlib import Path
+
+# Third Party
+from sri import Algorithm, calculate_integrity
+
+# Alliance Auth
+from allianceauth.services.hooks import get_extension_logger
+
+# Alliance Auth (External Libs)
+from app_utils.logging import LoggerAddTag
+
+# AA SRP
+from aasrp import __title__
+from aasrp.constants import AA_SRP_STATIC_DIR
+
+logger = LoggerAddTag(my_logger=get_extension_logger(__name__), prefix=__title__)
+
+
+def calculate_integrity_hash(relative_file_path: str) -> str:
+    """
+    Calculates the integrity hash for a given static file
+    :param self:
+    :type self:
+    :param relative_file_path: The file path relative to the `aa-srp/aasrp/static/aasrp` folder
+    :type relative_file_path: str
+    :return: The integrity hash
+    :rtype: str
+    """
+
+    file_path = os.path.join(AA_SRP_STATIC_DIR, relative_file_path)
+    integrity_hash = calculate_integrity(
+        path=Path(file_path), algorithm=Algorithm.SHA512
+    )
+
+    return integrity_hash

--- a/aasrp/templates/aasrp/bundles/aa-srp-css.html
+++ b/aasrp/templates/aasrp/bundles/aa-srp-css.html
@@ -1,8 +1,3 @@
 {% load aasrp %}
 
-<link
-    rel="stylesheet"
-    href="{% aasrp_static 'aasrp/css/aa-srp.min.css' %}"
-    integrity="sha512-eeN/pqBQ+41AVmNR+UyHjrSZvK0fpd5c14yV4NHnQEEXseMMZQu794m/PJ4usfZyQnZS2t4kFWDusnWZhC+HWw=="
-    crossorigin="anonymous"
->
+{% aasrp_static "css/aa-srp.min.css" %}

--- a/aasrp/templates/aasrp/bundles/aa-srp-form-css.html
+++ b/aasrp/templates/aasrp/bundles/aa-srp-form-css.html
@@ -1,8 +1,3 @@
 {% load aasrp %}
 
-<link
-    rel="stylesheet"
-    href="{% aasrp_static 'aasrp/css/aa-srp-form.min.css' %}"
-    integrity="sha512-y6ANPtPgBNxGQhYYNN3EI5bpLtzy/IVAJ18I5MdjnCIel2fCnD34H3dkHdOpt8ZiaKb9T/NRjS5rxlQynP9hlQ=="
-    crossorigin="anonymous"
->
+{% aasrp_static "css/aa-srp-form.min.css" %}

--- a/aasrp/templates/aasrp/bundles/aa-srp-form-js.html
+++ b/aasrp/templates/aasrp/bundles/aa-srp-form-js.html
@@ -1,7 +1,3 @@
 {% load aasrp %}
 
-<script
-    src="{% aasrp_static 'aasrp/javascript/form.min.js' %}"
-    integrity="sha512-ln1VzEG3ExrwRcfqIxE9WUXh81N4t2LJSq+bLrMGx4m1X/kwxbtSpDGD7EMwsDgtRCxKecPrnvw2VRf5lG8M9w=="
-    crossorigin="anonymous"
-></script>
+{% aasrp_static "javascript/form.min.js" %}

--- a/aasrp/templates/aasrp/bundles/aa-srp-js.html
+++ b/aasrp/templates/aasrp/bundles/aa-srp-js.html
@@ -1,7 +1,3 @@
 {% load aasrp %}
 
-<script
-    src="{% aasrp_static 'aasrp/javascript/aa-srp.min.js' %}"
-    integrity="sha512-SKL5pQAdZ1elLpwQNAi7E/kiO9txWBFPyYzCuClBx4psUpPwezz0LviMO8VEO09m0C7/q1KWLZPxXNJA/Igwxg=="
-    crossorigin="anonymous"
-></script>
+{% aasrp_static "javascript/aa-srp.min.js" %}

--- a/aasrp/templates/aasrp/bundles/my-srp-requests-js.html
+++ b/aasrp/templates/aasrp/bundles/my-srp-requests-js.html
@@ -1,7 +1,3 @@
 {% load aasrp %}
 
-<script
-    src="{% aasrp_static 'aasrp/javascript/my-srp-requests.min.js' %}"
-    integrity="sha512-HAmMdsguzaj4WiEQFNjvu6ykL70u/Tucj8aggl5grtLcSHNq8+Qcqi+oAhR02DI6WI04WfsFGVsIZsiPiHbohQ=="
-    crossorigin="anonymous"
-></script>
+{% aasrp_static "javascript/my-srp-requests.min.js" %}

--- a/aasrp/templates/aasrp/bundles/srp-links-js.html
+++ b/aasrp/templates/aasrp/bundles/srp-links-js.html
@@ -1,7 +1,3 @@
 {% load aasrp %}
 
-<script
-    src="{% aasrp_static 'aasrp/javascript/srp-links.min.js' %}"
-    integrity="sha512-qIB1r3Oqer36+Ujp4Y/cihZVpUf3mAEYerpQ2UqIjVkLpPMHAqoSOrf+wGq22isAKTjfSK4+9GWJlHbLnViaTw=="
-    crossorigin="anonymous"
-></script>
+{% aasrp_static "javascript/srp-links.min.js" %}

--- a/aasrp/templates/aasrp/bundles/view-requests-js.html
+++ b/aasrp/templates/aasrp/bundles/view-requests-js.html
@@ -1,7 +1,3 @@
 {% load aasrp %}
 
-<script
-    src="{% aasrp_static 'aasrp/javascript/view-requests.min.js' %}"
-    integrity="sha512-OX093crku4t8qUaI+nb6M29X6XPXNcikn/yZcjYEGq0VeP4f862u3uynXwky/MkFKOHBucuaPLDjcCU7RGhrKQ=="
-    crossorigin="anonymous"
-></script>
+{% aasrp_static "javascript/view-requests.min.js" %}

--- a/aasrp/templates/aasrp/bundles/x-editable-css.html
+++ b/aasrp/templates/aasrp/bundles/x-editable-css.html
@@ -1,8 +1,3 @@
-{% load static %}
+{% load aasrp %}
 
-<link
-    rel="stylesheet"
-    href="{% static 'aasrp/libs/x-editable/1.5.4/bootstrap5-editable/css/bootstrap-editable.min.css' %}"
-    integrity="sha512-52DL7BCZnjDkln1qrZMe9qSt6KFBwrGAa4JqmrmwYrz+QIfBXyacLvmTrpIyqJdjcEqzw/3YOM4Xj32mDz4x3A=="
-    crossorigin="anonymous"
->
+{% aasrp_static "libs/x-editable/1.5.4/bootstrap5-editable/css/bootstrap-editable.min.css" %}

--- a/aasrp/templates/aasrp/bundles/x-editable-js.html
+++ b/aasrp/templates/aasrp/bundles/x-editable-js.html
@@ -1,7 +1,3 @@
-{% load static %}
+{% load aasrp %}
 
-<script
-    src="{% static 'aasrp/libs/x-editable/1.5.4/bootstrap5-editable/js/bootstrap-editable.min.js' %}"
-    integrity="sha512-GpwuhZ2LkD9jnasqgssH1FJQLHvIeW9T36ax9W3dv+8KSA3xURDoTffS1SD95KSb2fXuYWg0Z5sDoZ/Xx10GHA=="
-    crossorigin="anonymous"
-></script>
+{% aasrp_static "libs/x-editable/1.5.4/bootstrap5-editable/js/bootstrap-editable.min.js" %}

--- a/aasrp/templatetags/aasrp.py
+++ b/aasrp/templatetags/aasrp.py
@@ -2,37 +2,85 @@
 Versioned static URLs to break browser caches when changing the app version
 """
 
+# Standard Library
+import os
+
 # Django
+from django.conf import settings
 from django.contrib.auth.models import User
 from django.template.defaulttags import register
 from django.templatetags.static import static
+from django.utils.safestring import mark_safe
 
 # Alliance Auth
 from allianceauth.framework.api.user import get_main_character_name_from_user
+from allianceauth.services.hooks import get_extension_logger
+
+# Alliance Auth (External Libs)
+from app_utils.logging import LoggerAddTag
 
 # AA SRP
-from aasrp import __version__
+from aasrp import __title__, __version__
+from aasrp.helper.static_files import calculate_integrity_hash
+
+logger = LoggerAddTag(my_logger=get_extension_logger(__name__), prefix=__title__)
 
 
 @register.simple_tag
-def aasrp_static(path: str) -> str:
+def aasrp_static(relative_file_path: str, script_type: str = None) -> str | None:
     """
     Versioned static URL
-    Adding the app version to any static file we load through this function.
-    This is to make sure to break the browser cache on app updates.
 
-    Example: /static/myapp/css/myapp.css?ver=1.0.0
-
-    :param path:
-    :type path:
-    :return:
-    :rtype:
+    :param relative_file_path: The file path relative to the `aa-srp/aasrp/static/aasrp` folder
+    :type relative_file_path: str
+    :param script_type: The script type
+    :type script_type: str
+    :return: Versioned static URL
+    :rtype: str
     """
 
-    static_url = static(path)
-    versioned_url = static_url + "?v=" + __version__
+    logger.debug(f"Getting versioned static URL for: {relative_file_path}")
 
-    return versioned_url
+    file_type = os.path.splitext(relative_file_path)[1][1:]
+
+    logger.debug(f"File extension: {file_type}")
+
+    # Only support CSS and JS files
+    if file_type not in ["css", "js"]:
+        raise ValueError(f"Unsupported file type: {file_type}")
+
+    static_file_path = os.path.join("aasrp", relative_file_path)
+    static_url = static(static_file_path)
+
+    # Integrity hash calculation only for non-debug mode
+    sri_string = (
+        f' integrity="{calculate_integrity_hash(relative_file_path)}" crossorigin="anonymous"'
+        if not settings.DEBUG
+        else ""
+    )
+
+    # Versioned URL for CSS and JS files
+    # Add version query parameter to break browser caches when changing the app version
+    # Do not add version query parameter for libs as they are already versioned through their file path
+    versioned_url = (
+        static_url
+        if relative_file_path.startswith("libs/")
+        else static_url + "?v=" + __version__
+    )
+
+    # Return the versioned URL with integrity hash for CSS
+    if file_type == "css":
+        return mark_safe(f'<link rel="stylesheet" href="{versioned_url}"{sri_string}>')
+
+    # Return the versioned URL with integrity hash for JS files
+    if file_type == "js":
+        js_type = f' type="{script_type}"' if script_type else ""
+
+        return mark_safe(
+            f'<script{js_type} src="{versioned_url}"{sri_string}></script>'
+        )
+
+    return None
 
 
 @register.filter

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dynamic = [
     "version",
 ]
 dependencies = [
-    "allianceauth>=4.3.1,<5",
+    "allianceauth>=4.6,<5",
     "allianceauth-app-utils>=1.25",
     "django-eveuniverse>=1.5.4",
 ]


### PR DESCRIPTION
## Description

### Changed

- Use `django-sri` for sri hashes
- Minimum requirements
  - Alliance Auth >= 4.6.0

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
