### PR TITLE
[FIX] Missing currency re-added

### DIFF
--- a/aasrp/helper/srp_data.py
+++ b/aasrp/helper/srp_data.py
@@ -45,6 +45,23 @@ def payout_amount_html(payout_amount: int) -> str:
         data=str(payout_amount), title=_("Copy payout amount to clipboard")
     )
     payout_amount_localized = l10n_number_format(payout_amount)
-    payout_field = f'<span class="srp-payout-tooltip"><span class="srp-payout-amount d-block cursor-pointer">{payout_amount_localized}</span></span>'
+    payout_field = f'<span class="srp-payout-tooltip"><span class="srp-payout-amount d-block cursor-pointer">{payout_amount_localized} ISK</span></span>'
 
     return f'<span class="srp-payout d-flex justify-content-end align-items-baseline">{payout_field}<sup>{payout_amount_ctc_icon}</sup></span>'
+
+
+def zkillboard_loss_amount_html(loss_amount: int) -> str:
+    """
+    Get HTML for localized zkillboard loss amount
+
+    :param request:
+    :type request:
+    :param loss_amount:
+    :type loss_amount:
+    :return:
+    :rtype:
+    """
+
+    loss_amount_localized = l10n_number_format(loss_amount)
+
+    return f"{loss_amount_localized} ISK"

--- a/aasrp/locale/django.pot
+++ b/aasrp/locale/django.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: AA SRP 2.7.0\n"
 "Report-Msgid-Bugs-To: https://github.com/ppfeufer/aa-srp/issues\n"
-"POT-Creation-Date: 2025-04-01 00:51+0200\n"
+"POT-Creation-Date: 2025-04-01 01:44+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -220,53 +220,53 @@ msgstr ""
 msgid "Copy character name to clipboard"
 msgstr ""
 
-#: aasrp/helper/icons.py:43 aasrp/templates/aasrp/request-srp.html:6
+#: aasrp/helper/icons.py:41 aasrp/templates/aasrp/request-srp.html:6
 msgid "Request SRP"
 msgstr ""
 
-#: aasrp/helper/icons.py:57
+#: aasrp/helper/icons.py:55
 msgid "View SRP requests"
 msgstr ""
 
-#: aasrp/helper/icons.py:71
+#: aasrp/helper/icons.py:69
 #: aasrp/templates/aasrp/partials/link-edit/form.html:19
 msgid "Add/Change AAR link"
 msgstr ""
 
-#: aasrp/helper/icons.py:82
+#: aasrp/helper/icons.py:80
 #: aasrp/templates/aasrp/modals/dashboard/disable-srp-link.html:4
 #: aasrp/templates/aasrp/modals/dashboard/disable-srp-link.html:9
 msgid "Disable SRP link"
 msgstr ""
 
-#: aasrp/helper/icons.py:101
+#: aasrp/helper/icons.py:99
 #: aasrp/templates/aasrp/modals/dashboard/enable-srp-link.html:4
 #: aasrp/templates/aasrp/modals/dashboard/enable-srp-link.html:9
 msgid "Enable SRP link"
 msgstr ""
 
-#: aasrp/helper/icons.py:119
+#: aasrp/helper/icons.py:117
 msgid "Remove SRP ink"
 msgstr ""
 
-#: aasrp/helper/icons.py:152
+#: aasrp/helper/icons.py:150
 msgid "SRP request pending"
 msgstr ""
 
-#: aasrp/helper/icons.py:164
+#: aasrp/helper/icons.py:162
 msgid "SRP request approved"
 msgstr ""
 
-#: aasrp/helper/icons.py:176 aasrp/views/ajax.py:688
+#: aasrp/helper/icons.py:174 aasrp/views/ajax.py:690
 msgid "SRP request rejected"
 msgstr ""
 
-#: aasrp/helper/icons.py:212
+#: aasrp/helper/icons.py:210
 #: aasrp/templates/aasrp/modals/view-requests/request-details.html:9
 msgid "SRP request details"
 msgstr ""
 
-#: aasrp/helper/icons.py:262
+#: aasrp/helper/icons.py:260
 #: aasrp/templates/aasrp/modals/view-requests/accept-rejected-request.html:10
 #: aasrp/templates/aasrp/modals/view-requests/accept-rejected-request.html:40
 #: aasrp/templates/aasrp/modals/view-requests/accept-request.html:10
@@ -274,22 +274,22 @@ msgstr ""
 msgid "Accept SRP request"
 msgstr ""
 
-#: aasrp/helper/icons.py:306
+#: aasrp/helper/icons.py:304
 #: aasrp/templates/aasrp/modals/view-requests/reject-request.html:10
 #: aasrp/templates/aasrp/modals/view-requests/reject-request.html:40
 msgid "Reject SRP request"
 msgstr ""
 
-#: aasrp/helper/icons.py:346
+#: aasrp/helper/icons.py:344
 #: aasrp/templates/aasrp/modals/view-requests/delete-request.html:9
 msgid "Delete SRP request"
 msgstr ""
 
-#: aasrp/helper/srp_data.py:21
+#: aasrp/helper/srp_data.py:26
 msgid "Copy request code to clipboard"
 msgstr ""
 
-#: aasrp/helper/srp_data.py:40
+#: aasrp/helper/srp_data.py:45
 msgid "Copy payout amount to clipboard"
 msgstr ""
 
@@ -863,23 +863,23 @@ msgstr ""
 msgid "This field is required."
 msgstr ""
 
-#: aasrp/views/ajax.py:117
+#: aasrp/views/ajax.py:119
 msgid "Link"
 msgstr ""
 
-#: aasrp/views/ajax.py:125
+#: aasrp/views/ajax.py:127
 msgid "Copy SRP link to clipboard"
 msgstr ""
 
-#: aasrp/views/ajax.py:602
+#: aasrp/views/ajax.py:604
 msgid "SRP request has been approved"
 msgstr ""
 
-#: aasrp/views/ajax.py:693
+#: aasrp/views/ajax.py:695
 msgid "SRP request has been rejected"
 msgstr ""
 
-#: aasrp/views/ajax.py:730
+#: aasrp/views/ajax.py:732
 msgid "SRP request has been removed"
 msgstr ""
 

--- a/aasrp/tests/test_helper_srp_data.py
+++ b/aasrp/tests/test_helper_srp_data.py
@@ -7,7 +7,11 @@ from django.test import TestCase, override_settings
 
 # AA SRP
 from aasrp.helper.icons import copy_to_clipboard_icon
-from aasrp.helper.srp_data import payout_amount_html, request_code_html
+from aasrp.helper.srp_data import (
+    payout_amount_html,
+    request_code_html,
+    zkillboard_loss_amount_html,
+)
 
 
 class TestPayoutAmountHtml(TestCase):
@@ -26,7 +30,10 @@ class TestPayoutAmountHtml(TestCase):
 
         result = payout_amount_html(1000)
 
-        self.assertIn("1,000", result)
+        self.assertIn(
+            '<span class="srp-payout-amount d-block cursor-pointer">1,000 ISK</span>',
+            result,
+        )
         self.assertIn('data-clipboard-text="1000"', result)
 
     @override_settings(LANGUAGE_CODE="de")
@@ -40,7 +47,10 @@ class TestPayoutAmountHtml(TestCase):
 
         result = payout_amount_html(1000)
 
-        self.assertIn("1.000", result)
+        self.assertIn(
+            '<span class="srp-payout-amount d-block cursor-pointer">1.000 ISK</span>',
+            result,
+        )
         self.assertIn('data-clipboard-text="1000"', result)
 
     @override_settings(LANGUAGE_CODE="en")
@@ -54,6 +64,10 @@ class TestPayoutAmountHtml(TestCase):
 
         result = payout_amount_html(0)
 
+        self.assertIn(
+            '<span class="srp-payout-amount d-block cursor-pointer">0 ISK</span>',
+            result,
+        )
         self.assertIn('data-clipboard-text="0"', result)
 
     @override_settings(LANGUAGE_CODE="de")
@@ -67,6 +81,10 @@ class TestPayoutAmountHtml(TestCase):
 
         result = payout_amount_html(0)
 
+        self.assertIn(
+            '<span class="srp-payout-amount d-block cursor-pointer">0 ISK</span>',
+            result,
+        )
         self.assertIn('data-clipboard-text="0"', result)
 
     @override_settings(LANGUAGE_CODE="en")
@@ -80,7 +98,10 @@ class TestPayoutAmountHtml(TestCase):
 
         result = payout_amount_html(-1000)
 
-        self.assertIn("-1,000", result)
+        self.assertIn(
+            '<span class="srp-payout-amount d-block cursor-pointer">-1,000 ISK</span>',
+            result,
+        )
         self.assertIn('data-clipboard-text="-1000"', result)
 
     @override_settings(LANGUAGE_CODE="de")
@@ -94,7 +115,10 @@ class TestPayoutAmountHtml(TestCase):
 
         result = payout_amount_html(-1000)
 
-        self.assertIn("-1.000", result)
+        self.assertIn(
+            '<span class="srp-payout-amount d-block cursor-pointer">-1.000 ISK</span>',
+            result,
+        )
         self.assertIn('data-clipboard-text="-1000"', result)
 
     @override_settings(LANGUAGE_CODE="en")
@@ -108,7 +132,10 @@ class TestPayoutAmountHtml(TestCase):
 
         result = payout_amount_html(1000000000)
 
-        self.assertIn("1,000,000,000", result)
+        self.assertIn(
+            '<span class="srp-payout-amount d-block cursor-pointer">1,000,000,000 ISK</span>',
+            result,
+        )
         self.assertIn('data-clipboard-text="1000000000"', result)
 
     @override_settings(LANGUAGE_CODE="de")
@@ -122,7 +149,10 @@ class TestPayoutAmountHtml(TestCase):
 
         result = payout_amount_html(1000000000)
 
-        self.assertIn("1.000.000.000", result)
+        self.assertIn(
+            '<span class="srp-payout-amount d-block cursor-pointer">1.000.000.000 ISK</span>',
+            result,
+        )
         self.assertIn('data-clipboard-text="1000000000"', result)
 
 
@@ -146,3 +176,97 @@ class TestRequestCodeHtml(TestCase):
         )
 
         self.assertEqual(result, f"ABC123<sup>{icon}</sup>")
+
+
+class TestZkillboardLossAmountHtml(TestCase):
+    """
+    Test cases for the zkillboard_loss_amount_html function.
+    """
+
+    @override_settings(LANGUAGE_CODE="en")
+    def test_zkillboard_loss_amount_html_returns_correct_html_locale_en(self):
+        """
+        Test localization of zkillboard loss amount HTML in English locale.
+
+        :return:
+        :rtype:
+        """
+
+        self.assertEqual(zkillboard_loss_amount_html(1000), "1,000 ISK")
+
+    @override_settings(LANGUAGE_CODE="de")
+    def test_zkillboard_loss_amount_html_returns_correct_html_locale_de(self):
+        """
+        Test localization of zkillboard loss amount HTML in German locale.
+
+        :return:
+        :rtype:
+        """
+
+        self.assertEqual(zkillboard_loss_amount_html(1000), "1.000 ISK")
+
+    @override_settings(LANGUAGE_CODE="en")
+    def test_zkillboard_loss_amount_html_handles_zero_locale_en(self):
+        """
+        Test localization of zkillboard loss amount HTML with zero in English locale.
+
+        :return:
+        :rtype:
+        """
+
+        self.assertEqual(zkillboard_loss_amount_html(0), "0 ISK")
+
+    @override_settings(LANGUAGE_CODE="de")
+    def test_zkillboard_loss_amount_html_handles_zero_locale_de(self):
+        """
+        Test localization of zkillboard loss amount HTML with zero in German locale.
+
+        :return:
+        :rtype:
+        """
+
+        self.assertEqual(zkillboard_loss_amount_html(0), "0 ISK")
+
+    @override_settings(LANGUAGE_CODE="en")
+    def test_zkillboard_loss_amount_html_handles_negative_amount_locale_en(self):
+        """
+        Test localization of zkillboard loss amount HTML with negative amount in English locale.
+
+        :return:
+        :rtype:
+        """
+
+        self.assertEqual(zkillboard_loss_amount_html(-1000), "-1,000 ISK")
+
+    @override_settings(LANGUAGE_CODE="de")
+    def test_zkillboard_loss_amount_html_handles_negative_amount_locale_de(self):
+        """
+        Test localization of zkillboard loss amount HTML with negative amount in German locale.
+
+        :return:
+        :rtype:
+        """
+
+        self.assertEqual(zkillboard_loss_amount_html(-1000), "-1.000 ISK")
+
+    @override_settings(LANGUAGE_CODE="en")
+    def test_zkillboard_loss_amount_html_handles_large_amount_locale_en(self):
+        """
+        Test localization of zkillboard loss amount HTML with a large amount in English locale.
+
+        :return:
+        :rtype:
+        """
+
+        self.assertEqual(zkillboard_loss_amount_html(1000000000), "1,000,000,000 ISK")
+
+    @override_settings(LANGUAGE_CODE="de")
+    def test_zkillboard_loss_amount_html_handles_large_amount_locale_de(self):
+        """
+        Test localization of zkillboard loss amount HTML with a large amount in German locale.
+
+        :return:
+        :rtype:
+        """
+
+        self.assertEqual(zkillboard_loss_amount_html(1000000000), "1.000.000.000 ISK")

--- a/aasrp/views/ajax.py
+++ b/aasrp/views/ajax.py
@@ -39,8 +39,11 @@ from aasrp.helper.icons import (
     get_srp_request_details_icon,
     get_srp_request_status_icon,
 )
-from aasrp.helper.numbers import l10n_number_format
-from aasrp.helper.srp_data import payout_amount_html, request_code_html
+from aasrp.helper.srp_data import (
+    payout_amount_html,
+    request_code_html,
+    zkillboard_loss_amount_html,
+)
 from aasrp.helper.user import get_user_settings
 from aasrp.managers import SrpManager
 from aasrp.models import RequestComment, SrpLink, SrpRequest
@@ -341,7 +344,7 @@ def srp_link_view_requests_data(request: WSGIRequest, srp_code: str) -> JsonResp
                 "ship": srp_request.ship.name,
                 "zkb_link": killboard_link,
                 "zkb_loss_amount_html": {
-                    "display": l10n_number_format(srp_request.loss_amount),
+                    "display": zkillboard_loss_amount_html(srp_request.loss_amount),
                     "sort": srp_request.loss_amount,
                 },
                 "zbk_loss_amount": srp_request.loss_amount,


### PR DESCRIPTION
### Fixed

- Missing currency re-added

Ensures payout and ZKillboard loss amounts are displayed with the "ISK" currency symbol for clarity and consistency.

This commit reintroduces the currency symbol to the payout and loss amount displays, which was previously unintentionally removed. It also adds a new helper function to format ZKillboard loss amounts with localization support.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
