### PR TITLE
[FIX] Don't try to translate Discord messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,10 @@ Section Order:
 
 - Ajax calls logic refactored
 
+### Fixed
+
+- Don't try to translate Discord messages, it's not working
+
 ## [2.7.1] - 2025-04-07
 
 ### Changed

--- a/aasrp/locale/django.pot
+++ b/aasrp/locale/django.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: AA SRP 2.7.1\n"
 "Report-Msgid-Bugs-To: https://github.com/ppfeufer/aa-srp/issues\n"
-"POT-Creation-Date: 2025-04-08 12:44+0200\n"
+"POT-Creation-Date: 2025-04-08 12:58+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -875,11 +875,6 @@ msgstr ""
 
 #: aasrp/views/ajax.py:499 aasrp/views/ajax.py:605
 msgid "Invalid form data"
-msgstr ""
-
-#: aasrp/views/ajax.py:538
-#, python-brace-format
-msgid "Your SRP request regarding your {srp_request.ship.name} lost during "
 msgstr ""
 
 #: aasrp/views/ajax.py:563

--- a/aasrp/views/ajax.py
+++ b/aasrp/views/ajax.py
@@ -534,7 +534,7 @@ def srp_request_approve(  # pylint: disable=too-many-locals
                     "\n" "Comment:" "\n" f"{reviser_comment}" "\n\n"
                 )
 
-            notification_message = _(
+            notification_message = (
                 f"Your SRP request regarding your {srp_request.ship.name} lost during "
                 f"{srp_request.srp_link.srp_name} has been approved."
                 "\n\n"


### PR DESCRIPTION
## Description

### Fixed

- Don't try to translate Discord messages, it's not working

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
