### PR TITLE
[FIX] Accidentally escaping apostrophes in character names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,10 @@ Section Order:
 ### Security
 -->
 
+### Fixed
+
+- Accidentally escaping apostrophes in character names in the SRP request notification
+
 ## [2.8.1] - 2025-05-05
 
 ### Changed

--- a/aasrp/templates/aasrp/notifications/discord/request-status-change.html
+++ b/aasrp/templates/aasrp/notifications/discord/request-status-change.html
@@ -1,11 +1,11 @@
-Your SRP request regarding your {{ ship }} lost during Test SRP has been {{ status }}.
+Your SRP request regarding your {{ ship|safe }} lost during Test SRP has been {{ status }}.
 
 __**Request Details:**__
 **SRP Code:** {{ srp_code }}
 **Request Code:** {{ request_code }}
-**Reviser:** {{ reviser }}
+**Reviser:** {{ reviser|safe }}
 {% if comment %}
 __**Comment:**__
-{{ comment }}
+{{ comment|safe }}
 {% endif %}
 If you have any questions regarding your SRP request, feel free to contact your request reviser. Please make sure to always add the SRP code, and the request code with your inquiry.

--- a/aasrp/templates/aasrp/notifications/discord/srp-team.html
+++ b/aasrp/templates/aasrp/notifications/discord/srp-team.html
@@ -1,12 +1,12 @@
-### {{ character }} / {{ ship }}
+### {{ character|safe }} / {{ ship }}
 
 __**Request Details:**__
-**Character:** {{ character }}
-**Ship:** {{ ship }}
+**Character:** {{ character|safe }}
+**Ship:** {{ ship|safe }}
 **SRP Code:** {{ srp_code }}
 **SRP Link:** {{ srp_link }}
 **Request Code:** {{ request_code }}
 **zKillboard Link:** {{ killboard_link }}
 
 __**Additional Information:**__
-{{ additional_info }}
+{{ additional_info|safe }}


### PR DESCRIPTION
## Description

### Fixed

- Accidentally escaping apostrophes in character names in the SRP request notification

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
