### PR TITLE
[RELEASE] v2.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,9 +41,15 @@ Section Order:
 ### Security
 -->
 
+## [2.9.0] - 2025-06-03
+
 ### Fixed
 
 - Accidentally escaping apostrophes in character names in the SRP request notification
+
+### Changed
+
+- Translations updated
 
 ### Removed
 

--- a/aasrp/__init__.py
+++ b/aasrp/__init__.py
@@ -5,5 +5,5 @@ App init
 # Django
 from django.utils.translation import gettext_lazy as _
 
-__version__ = "2.8.1"
+__version__ = "2.9.0"
 __title__ = _("Ship Replacement")

--- a/aasrp/locale/django.pot
+++ b/aasrp/locale/django.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: AA SRP 2.8.1\n"
+"Project-Id-Version: AA SRP 2.9.0\n"
 "Report-Msgid-Bugs-To: https://github.com/ppfeufer/aa-srp/issues\n"
-"POT-Creation-Date: 2025-05-06 00:31+0200\n"
+"POT-Creation-Date: 2025-06-03 13:55+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"


### PR DESCRIPTION
## [2.9.0] - 2025-06-03

### Fixed

- Accidentally escaping apostrophes in character names in the SRP request notification

### Changed

- Translations updated

### Removed

- Cache breaker for static files. Doesn't work as expected with `django-sri`.