### PR TITLE
[RELEASE] v2.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ Section Order:
 ### Security
 -->
 
+## [2.10.0] - 2025-07-08
+
 ### Added
 
 - New dependency

--- a/aasrp/__init__.py
+++ b/aasrp/__init__.py
@@ -5,7 +5,7 @@ App init
 # Django
 from django.utils.translation import gettext_lazy as _
 
-__version__ = "2.9.2"
+__version__ = "2.10.0"
 __title__ = _("Ship Replacement")
 
 __package_name__ = "aa-srp"


### PR DESCRIPTION
## [2.10.0] - 2025-07-08

### Added

- New dependency
  - `django-esi>=7.0.1`

### Changed

- User Agent generation updated to match latest `django-esi` guidelines