### PR TITLE
[RELEASE] v2.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,11 +41,14 @@ Section Order:
 ### Security
 -->
 
+## [2.12.0] - 2025-08-14
+
 ### Changed
 
 - Use AA framework JS functions
 - Minimum requirements
   - Alliance Auth >= 4.9.0
+- Translations updated
 
 ## [2.11.0] - 2025-08-05
 

--- a/aasrp/__init__.py
+++ b/aasrp/__init__.py
@@ -5,7 +5,7 @@ App init
 # Django
 from django.utils.translation import gettext_lazy as _
 
-__version__ = "2.11.0"
+__version__ = "2.12.0"
 __title__ = _("Ship Replacement")
 
 __package_name__ = "aa-srp"


### PR DESCRIPTION
## [2.12.0] - 2025-08-14

### Changed

- Use AA framework JS functions
- Minimum requirements
  - Alliance Auth >= 4.9.0
- Translations updated