### PR TITLE
[ADD] Check for missing trailing slashes in killmail URLs (#348)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,10 @@ Section Order:
 ### Security
 -->
 
+### Added
+
+- Check for missing trailing slashes in killmail URLs and add them if necessary (#348)
+
 ### Changed
 
 - Simplify Discord embed color mapping

--- a/aasrp/constants.py
+++ b/aasrp/constants.py
@@ -37,16 +37,19 @@ KILLBOARD_DATA = {
         "api_url": "https://zkillboard.com/api/",
         "base_url_regex": r"^http[s]?:\/\/zkillboard\.com\/",
         "killmail_url_regex": r"^http[s]?:\/\/zkillboard\.com\/kill\/\d+\/",
+        "requires_trailing_slash": True,
     },
     "EveTools": {
         "base_url": "https://kb.evetools.org/",
         "base_url_regex": r"^http[s]?:\/\/kb\.evetools\.org\/",
         "killmail_url_regex": r"^http[s]?:\/\/kb\.evetools\.org\/kill\/\d+",
+        "requires_trailing_slash": True,
     },
     "EVE-KILL": {
         "base_url": "https://eve-kill.com/",
         "base_url_regex": r"^http[s]?:\/\/eve-kill\.com\/",
         "killmail_url_regex": r"^http[s]?:\/\/eve-kill\.com\/kill\/\d+",
+        "requires_trailing_slash": True,
     },
 }
 

--- a/aasrp/tests/test_forms.py
+++ b/aasrp/tests/test_forms.py
@@ -1,0 +1,146 @@
+"""
+Tests for form.py
+"""
+
+# Standard Library
+from unittest.mock import patch
+
+# Django
+from django.core.exceptions import ValidationError
+from django.test import TestCase
+
+# AA SRP
+from aasrp.constants import KILLBOARD_DATA
+from aasrp.form import SrpRequestForm
+
+
+class TestSrpRequestForm(TestCase):
+    """
+    Test SrpRequestForm
+    """
+
+    def test_validates_killboard_link_with_trailing_slash(self):
+        """
+        Test validates killboard link with trailing slash
+
+        :return:
+        :rtype:
+        """
+
+        form = SrpRequestForm(
+            data={
+                "killboard_link": "https://zkillboard.com/kill/123456/",
+                "additional_info": "Details",
+            }
+        )
+        form.cleaned_data = {"killboard_link": "https://zkillboard.com/kill/123456/"}
+
+        with patch(
+            "aasrp.form.KILLBOARD_DATA",
+            {"zKillboard": KILLBOARD_DATA.get("zKillboard")},
+        ):
+            self.assertEqual(
+                form.clean_killboard_link(), "https://zkillboard.com/kill/123456/"
+            )
+
+    def test_validates_killboard_link_without_trailing_slash(self):
+        """
+        Test validates killboard link without trailing slash and adds it if required
+
+        :return:
+        :rtype:
+        """
+
+        form = SrpRequestForm(
+            data={
+                "killboard_link": "https://zkillboard.com/kill/123456",
+                "additional_info": "Details",
+            }
+        )
+        form.cleaned_data = {"killboard_link": "https://zkillboard.com/kill/123456"}
+
+        with patch(
+            "aasrp.form.KILLBOARD_DATA",
+            {"zKillboard": KILLBOARD_DATA.get("zKillboard")},
+        ):
+            self.assertEqual(
+                form.clean_killboard_link(), "https://zkillboard.com/kill/123456/"
+            )
+
+    def test_raises_error_for_invalid_killboard_link(self):
+        """
+        Test raises error for invalid killboard link
+
+        :return:
+        :rtype:
+        """
+
+        form = SrpRequestForm(
+            data={
+                "killboard_link": "https://invalid.com/kill/123456/",
+                "additional_info": "Details",
+            }
+        )
+        form.cleaned_data = {"killboard_link": "https://invalid.com/kill/123456/"}
+
+        with patch(
+            "aasrp.form.KILLBOARD_DATA",
+            {"zKillboard": KILLBOARD_DATA.get("zKillboard")},
+        ):
+            with self.assertRaises(ValidationError) as cm:
+                form.clean_killboard_link()
+
+            self.assertIn("Invalid link", str(cm.exception))
+
+    def test_raises_error_for_non_killmail_link(self):
+        """
+        Test raises error for non-killmail link
+
+        :return:
+        :rtype:
+        """
+
+        form = SrpRequestForm(
+            data={
+                "killboard_link": "https://zkillboard.com/ship/123456/",
+                "additional_info": "Details",
+            }
+        )
+        form.cleaned_data = {"killboard_link": "https://zkillboard.com/ship/123456/"}
+
+        with patch(
+            "aasrp.form.KILLBOARD_DATA",
+            {"zKillboard": KILLBOARD_DATA.get("zKillboard")},
+        ):
+            with self.assertRaises(ValidationError) as cm:
+                form.clean_killboard_link()
+
+            self.assertIn(
+                "Invalid link. Please post a link to a kill mail.", str(cm.exception)
+            )
+
+    def test_raises_error_if_srp_request_already_exists(self):
+        """
+        Test raises error if SRP request already exists for the given killmail
+
+        :return:
+        :rtype:
+        """
+
+        form = SrpRequestForm(
+            data={
+                "killboard_link": "https://zkillboard.com/kill/123456/",
+                "additional_info": "Details",
+            }
+        )
+        form.cleaned_data = {"killboard_link": "https://zkillboard.com/kill/123456/"}
+
+        with patch("aasrp.form.SrpRequest.objects.filter") as mock_filter:
+            mock_filter.return_value.exists.return_value = True
+
+            with self.assertRaises(ValidationError) as cm:
+                form.clean_killboard_link()
+
+            self.assertIn(
+                "There is already an SRP request for this kill mail.", str(cm.exception)
+            )


### PR DESCRIPTION
## Description

### Added

- Check for missing trailing slashes in killmail URLs and add them if necessary (#348)

Fixes #348

## Type of Change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
