### PR TITLE
[FIX] Only render icon markup for top navigation when there is an icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,10 @@ Section Order:
 
 - Check for missing trailing slashes in killmail URLs and add them if necessary ([#348](https://github.com/ppfeufer/aa-srp/issues/348))
 
+### Fixed
+
+- Only render icon markup for top navigation buttons when there is an icon
+
 ### Changed
 
 - Simplify Discord embed color mapping

--- a/aasrp/templates/aasrp/partials/navigation/actions-navigation-item.html
+++ b/aasrp/templates/aasrp/partials/navigation/actions-navigation-item.html
@@ -5,7 +5,7 @@
         </span>
 
         <span class="d-inline-block d-lg-none">
-            <i class="{{ fa_icon }} me-2"></i>
+            {% if fa_icon %}<i class="{{ fa_icon }} me-2"></i>{% endif %}
             {{ title }}
         </span>
     </a>


### PR DESCRIPTION
## Description

### Fixed

- Only render icon markup for top navigation buttons when there is an icon

## Type of Change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
