### PR TITLE
[FIX] CSS classes in DataTables dropdown filter in My SRP Requests view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Section Order:
 
 ### Fixed
 
+- CSS classes in DataTables dropdown filter in "My SRP Requests" view
 - Take duplicate items in SDE into account
 
 ## [4.2.3] - 2026-04-08

--- a/aasrp/locale/django.pot
+++ b/aasrp/locale/django.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: AA SRP 4.2.3\n"
 "Report-Msgid-Bugs-To: https://github.com/ppfeufer/aa-srp/issues\n"
-"POT-Creation-Date: 2026-04-08 13:07+0200\n"
+"POT-Creation-Date: 2026-04-14 06:25+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -54,7 +54,7 @@ msgstr ""
 #: aasrp/admin.py:142 aasrp/models.py:326
 #: aasrp/templates/aasrp/ajax-render/srp-request-additional-information.html:41
 #: aasrp/templates/aasrp/dashboard.html:23
-#: aasrp/templates/aasrp/partials/view-own-requests/datatables-filter.html:20
+#: aasrp/templates/aasrp/partials/view-own-requests/datatables-filter.html:21
 #: aasrp/templates/aasrp/partials/view-own-requests/user-srp-requests.html:22
 #: aasrp/templates/aasrp/partials/view-requests/requests.html:82
 #: aasrp/templates/aasrp/view-own-requests.html:23
@@ -80,7 +80,7 @@ msgstr ""
 #: aasrp/admin.py:248 aasrp/models.py:317
 #: aasrp/templates/aasrp/ajax-render/srp-request-additional-information.html:27
 #: aasrp/templates/aasrp/dashboard.html:25
-#: aasrp/templates/aasrp/partials/view-own-requests/datatables-filter.html:8
+#: aasrp/templates/aasrp/partials/view-own-requests/datatables-filter.html:9
 #: aasrp/templates/aasrp/partials/view-own-requests/user-srp-requests.html:20
 #: aasrp/templates/aasrp/partials/view-requests/requests.html:80
 #: aasrp/templates/aasrp/view-own-requests.html:25
@@ -418,7 +418,7 @@ msgid "Who created the SRP request?"
 msgstr ""
 
 #: aasrp/models.py:338 aasrp/templates/aasrp/dashboard.html:24
-#: aasrp/templates/aasrp/partials/view-own-requests/datatables-filter.html:32
+#: aasrp/templates/aasrp/partials/view-own-requests/datatables-filter.html:33
 #: aasrp/templates/aasrp/partials/view-own-requests/user-srp-requests.html:34
 #: aasrp/templates/aasrp/view-own-requests.html:24
 #: aasrp/templates/aasrp/view-requests.html:34
@@ -837,31 +837,31 @@ msgstr ""
 msgid "Save settings"
 msgstr ""
 
-#: aasrp/templates/aasrp/partials/view-own-requests/datatables-filter.html:4
+#: aasrp/templates/aasrp/partials/view-own-requests/datatables-filter.html:5
 msgid "Filter your SRP requests by"
 msgstr ""
 
-#: aasrp/templates/aasrp/partials/view-own-requests/datatables-filter.html:10
+#: aasrp/templates/aasrp/partials/view-own-requests/datatables-filter.html:11
 msgid "All characters"
 msgstr ""
 
-#: aasrp/templates/aasrp/partials/view-own-requests/datatables-filter.html:22
+#: aasrp/templates/aasrp/partials/view-own-requests/datatables-filter.html:23
 msgid "All ships"
 msgstr ""
 
-#: aasrp/templates/aasrp/partials/view-own-requests/datatables-filter.html:34
+#: aasrp/templates/aasrp/partials/view-own-requests/datatables-filter.html:35
 msgid "All requests"
 msgstr ""
 
-#: aasrp/templates/aasrp/partials/view-own-requests/datatables-filter.html:35
+#: aasrp/templates/aasrp/partials/view-own-requests/datatables-filter.html:36
 msgid "Pending requests"
 msgstr ""
 
-#: aasrp/templates/aasrp/partials/view-own-requests/datatables-filter.html:36
+#: aasrp/templates/aasrp/partials/view-own-requests/datatables-filter.html:37
 msgid "Approved requests"
 msgstr ""
 
-#: aasrp/templates/aasrp/partials/view-own-requests/datatables-filter.html:37
+#: aasrp/templates/aasrp/partials/view-own-requests/datatables-filter.html:38
 msgid "Rejected requests"
 msgstr ""
 

--- a/aasrp/templates/aasrp/partials/view-own-requests/datatables-filter.html
+++ b/aasrp/templates/aasrp/partials/view-own-requests/datatables-filter.html
@@ -1,41 +1,43 @@
 {% load i18n %}
 
-<div class="aasrp-datatable-filters">
-    <p class="mb-1 fw-bold">{% translate "Filter your SRP requests by" %}:</p>
-    <div class="align-items-center d-flex flex-wrap gap-3 mb-3">
-{#        <div class="d-flex align-items-center gap-2">#}
-        <div>
-            <label for="filter-character" class="col-auto">{% translate "Character" %}</label>
-            <select id="filter-character" class="form-select w-auto">
-                <option value="">{% translate "All characters" %}</option>
+<div class="aasrp-datatable-filters dt-container">
+    <div class="row">
+        <p class="mb-1 fw-bold">{% translate "Filter your SRP requests by" %}:</p>
+        <div class="align-items-center d-flex flex-wrap gap-3 mb-3">
+{#            <div class="d-flex align-items-center gap-2">#}
+            <div>
+                <label for="filter-character" class="col-auto">{% translate "Character" %}</label>
+                <select id="filter-character" class="form-select w-auto">
+                    <option value="">{% translate "All characters" %}</option>
 
-                {% for character_name, character_id in characters %}
-                    <option value="{{ character_id }}">{{ character_name }}</option>
-                {% endfor %}
-            </select>
-        </div>
+                    {% for character_name, character_id in characters %}
+                        <option value="{{ character_id }}">{{ character_name }}</option>
+                    {% endfor %}
+                </select>
+            </div>
 
-{#        <div class="d-flex align-items-center gap-2">#}
-        <div>
-            <label for="filter-ship" class="col-auto">{% translate "Ship" %}</label>
-            <select id="filter-ship" class="form-select w-auto">
-                <option value="">{% translate "All ships" %}</option>
+{#            <div class="d-flex align-items-center gap-2">#}
+            <div>
+                <label for="filter-ship" class="col-auto">{% translate "Ship" %}</label>
+                <select id="filter-ship" class="form-select w-auto">
+                    <option value="">{% translate "All ships" %}</option>
 
-                {% for ship in ships %}
-                    <option value="{{ ship.id }}">{{ ship.name }}</option>
-                {% endfor %}
-            </select>
-        </div>
+                    {% for ship in ships %}
+                        <option value="{{ ship.id }}">{{ ship.name }}</option>
+                    {% endfor %}
+                </select>
+            </div>
 
-{#        <div class="d-flex align-items-center gap-2">#}
-        <div>
-            <label for="filter-request-status" class="col-auto">{% translate "Request status" %}</label>
-            <select id="filter-request-status" class="form-select w-auto">
-                <option value="">{% translate "All requests" %}</option>
-                <option value="Pending">{% translate "Pending requests" %}</option>
-                <option value="Approved">{% translate "Approved requests" %}</option>
-                <option value="Rejected">{% translate "Rejected requests" %}</option>
-            </select>
+{#            <div class="d-flex align-items-center gap-2">#}
+            <div>
+                <label for="filter-request-status" class="col-auto">{% translate "Request status" %}</label>
+                <select id="filter-request-status" class="form-select w-auto">
+                    <option value="">{% translate "All requests" %}</option>
+                    <option value="Pending">{% translate "Pending requests" %}</option>
+                    <option value="Approved">{% translate "Approved requests" %}</option>
+                    <option value="Rejected">{% translate "Rejected requests" %}</option>
+                </select>
+            </div>
         </div>
     </div>
 </div>

--- a/aasrp/templates/aasrp/partials/view-own-requests/user-srp-requests.html
+++ b/aasrp/templates/aasrp/partials/view-own-requests/user-srp-requests.html
@@ -10,9 +10,9 @@
             </div>
         </div>
 
-        {% include "aasrp/partials/view-own-requests/datatables-filter.html" %}
-
         <div class="table-responsive">
+            {% include "aasrp/partials/view-own-requests/datatables-filter.html" %}
+
             <table class="table table-striped table-aasrp table-srp-requests w-100" id="table_tab-user-srp-requests">
                 <thead>
                     <tr>


### PR DESCRIPTION
## Description

### Fixed

- CSS classes in DataTables dropdown filter in "My SRP Requests" view

## Type of Change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
