### PR TITLE
[RELEASE] v5.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ Section Order:
 
 <!-- Your changes go here -->
 
+## [5.0.0] - 2026-06-07
+
 > [!IMPORTANT]
 >
 > **This version needs Alliance Auth v5!**
@@ -1797,11 +1799,12 @@ python manage.py aasrp_update_db_relations
 [4.2.3]: https://github.com/ppfeufer/aa-srp/compare/v4.2.2...v4.2.3 "v4.2.3"
 [4.3.0]: https://github.com/ppfeufer/aa-srp/compare/v4.2.3...v4.3.0 "v4.3.0"
 [4.4.0]: https://github.com/ppfeufer/aa-srp/compare/v4.3.0...v4.4.0 "v4.4.0"
+[5.0.0]: https://github.com/ppfeufer/aa-srp/compare/v4.4.0...v5.0.0 "v5.0.0"
 [aa discord notify]: https://gitlab.com/ErikKalkoken/aa-discordnotify "AA Discord Notify"
 [aa fleet pings]: https://github.com/ppfeufer/aa-fleetpings "AA Fleet Pings"
 [aa-discordbot]: https://github.com/pvyParts/allianceauth-discordbot "AA-Discordbot"
 [evetools killboard]: https://kb.evetools.org/ "EveTools Killboard"
-[in development]: https://github.com/ppfeufer/aa-srp/compare/v4.4.0...HEAD "In Development"
+[in development]: https://github.com/ppfeufer/aa-srp/compare/v5.0.0...HEAD "In Development"
 [keep a changelog]: http://keepachangelog.com/ "Keep a Changelog"
 [semantic versioning]: http://semver.org/ "Semantic Versioning"
 [tooltip: change srp payout amount]: https://raw.githubusercontent.com/ppfeufer/aa-srp/master/docs/images/tooltip-change-srp-payout-amount.png "Tooltip: Change SRP Payout Amount"

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Make sure you're in the virtual environment (venv) of your Alliance Auth
 installation Then install the latest release directly from PyPi.
 
 ```shell
-pip install aa-srp==4.4.0
+pip install aa-srp==5.0.0
 ```
 
 #### Step 2: Configure Alliance Auth<a name="step-2-configure-alliance-auth"></a>
@@ -183,7 +183,7 @@ Restart your supervisor services for Auth
 Add the app to your `conf/requirements.txt`
 
 ```requirements
-aa-srp==4.4.0
+aa-srp==5.0.0
 ```
 
 #### Step 2: Update Your AA Settings<a name="step-2-update-your-aa-settings"></a>
@@ -309,7 +309,7 @@ To update your existing installation of AA SRP, first enable your virtual enviro
 Then run the following command to update AA SRP to the latest version.
 
 ```shell
-pip install aa-srp==4.4.0
+pip install aa-srp==5.0.0
 
 python manage.py collectstatic
 python manage.py migrate
@@ -325,7 +325,7 @@ To update your existing installation of AA SRP, first update the version in your
 `conf/requirements.txt` to the latest version.
 
 ```requirements
-aa-srp==4.4.0
+aa-srp==5.0.0
 ```
 
 Then build your Auth container and restart your containers.

--- a/aasrp/__init__.py
+++ b/aasrp/__init__.py
@@ -6,7 +6,7 @@ This module defines metadata and constants for the Ship Replacement Program (SRP
 # Django
 from django.utils.translation import gettext_lazy as _
 
-__version__ = "4.4.0"
+__version__ = "5.0.0"
 __title__ = "Ship Replacement"
 __title_translated__ = _("Ship Replacement")
 __verbose_name__ = "Ship Replacement (SRP) for Alliance Auth"


### PR DESCRIPTION
## [5.0.0] - 2026-06-07

> [!IMPORTANT]
> 
> **This version needs Alliance Auth v5!**
> 
> Please make sure to update your Alliance Auth instance **before** you install this
> version, otherwise an update to Alliance Auth will be pulled in unsupervised.

> [!WARNING]
> 
> If you haven't updated to AA SRP v4 yet, please make sure to read the
> update instructions (v4.0.0 and v4.1.0) and update to at least v4.1.0 before
> updating to this version, otherwise, the app will not work properly.

### Removed

- Support for Alliance Auth v4
- Deprecated migrations