### PR TITLE
[RELEASE] v5.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ Section Order:
 
 <!-- Your changes go here -->
 
+## [5.1.0] - 2026-07-09
+
 > [!IMPORTANT]
 >
 > **This version needs Alliance Auth v5.2.0 or newer!**
@@ -1823,11 +1825,12 @@ python manage.py aasrp_update_db_relations
 [4.4.0]: https://github.com/ppfeufer/aa-srp/compare/v4.3.0...v4.4.0 "v4.4.0"
 [5.0.0]: https://github.com/ppfeufer/aa-srp/compare/v4.4.0...v5.0.0 "v5.0.0"
 [5.0.1]: https://github.com/ppfeufer/aa-srp/compare/v5.0.0...v5.0.1 "v5.0.1"
+[5.1.0]: https://github.com/ppfeufer/aa-srp/compare/v5.0.1...v5.1.0 "v5.1.0"
 [aa discord notify]: https://gitlab.com/ErikKalkoken/aa-discordnotify "AA Discord Notify"
 [aa fleet pings]: https://github.com/ppfeufer/aa-fleetpings "AA Fleet Pings"
 [aa-discordbot]: https://github.com/pvyParts/allianceauth-discordbot "AA-Discordbot"
 [evetools killboard]: https://kb.evetools.org/ "EveTools Killboard"
-[in development]: https://github.com/ppfeufer/aa-srp/compare/v5.0.1...HEAD "In Development"
+[in development]: https://github.com/ppfeufer/aa-srp/compare/v5.1.0...HEAD "In Development"
 [keep a changelog]: http://keepachangelog.com/ "Keep a Changelog"
 [semantic versioning]: http://semver.org/ "Semantic Versioning"
 [tooltip: change srp payout amount]: https://raw.githubusercontent.com/ppfeufer/aa-srp/master/docs/images/tooltip-change-srp-payout-amount.png "Tooltip: Change SRP Payout Amount"

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Make sure you're in the virtual environment (venv) of your Alliance Auth
 installation Then install the latest release directly from PyPi.
 
 ```shell
-pip install aa-srp==5.0.1
+pip install aa-srp==5.1.0
 ```
 
 #### Step 2: Configure Alliance Auth<a name="step-2-configure-alliance-auth"></a>
@@ -183,7 +183,7 @@ Restart your supervisor services for Auth
 Add the app to your `conf/requirements.txt`
 
 ```requirements
-aa-srp==5.0.1
+aa-srp==5.1.0
 ```
 
 #### Step 2: Update Your AA Settings<a name="step-2-update-your-aa-settings"></a>
@@ -309,7 +309,7 @@ To update your existing installation of AA SRP, first enable your virtual enviro
 Then run the following command to update AA SRP to the latest version.
 
 ```shell
-pip install aa-srp==5.0.1
+pip install aa-srp==5.1.0
 
 python manage.py collectstatic
 python manage.py migrate
@@ -325,7 +325,7 @@ To update your existing installation of AA SRP, first update the version in your
 `conf/requirements.txt` to the latest version.
 
 ```requirements
-aa-srp==5.0.1
+aa-srp==5.1.0
 ```
 
 Then build your Auth container and restart your containers.

--- a/aasrp/__init__.py
+++ b/aasrp/__init__.py
@@ -6,7 +6,7 @@ This module defines metadata and constants for the Ship Replacement Program (SRP
 # Django
 from django.utils.translation import gettext_lazy as _
 
-__version__ = "5.0.1"
+__version__ = "5.1.0"
 __title__ = "Ship Replacement"
 __title_translated__ = _("Ship Replacement")
 __verbose_name__ = "Ship Replacement (SRP) for Alliance Auth"

--- a/aasrp/locale/django.pot
+++ b/aasrp/locale/django.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: AA SRP 5.0.1\n"
+"Project-Id-Version: AA SRP 5.1.0\n"
 "Report-Msgid-Bugs-To: https://github.com/ppfeufer/aa-srp/issues\n"
-"POT-Creation-Date: 2026-07-07 10:45+0200\n"
+"POT-Creation-Date: 2026-07-09 12:35+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -29,7 +29,7 @@ msgid "Ship Replacement"
 msgstr ""
 
 #: aasrp/admin.py:57 aasrp/models.py:163 aasrp/models.py:309
-#: aasrp/models.py:491
+#: aasrp/models.py:489
 #: aasrp/templates/aasrp/partials/dashboard/srp-links.html:18
 msgid "Creator"
 msgstr ""
@@ -182,7 +182,7 @@ msgstr ""
 msgid "Killboard link"
 msgstr ""
 
-#: aasrp/form.py:232 aasrp/form.py:241 aasrp/models.py:332 aasrp/models.py:470
+#: aasrp/form.py:232 aasrp/form.py:241 aasrp/models.py:332 aasrp/models.py:468
 #: aasrp/templates/aasrp/ajax-render/srp-request-additional-information.html:82
 #: aasrp/templates/aasrp/view-own-requests.html:27
 #: aasrp/templates/aasrp/view-requests.html:43
@@ -214,7 +214,7 @@ msgstr ""
 msgid "Please provide the reason this SRP request is rejected."
 msgstr ""
 
-#: aasrp/form.py:388 aasrp/models.py:352 aasrp/models.py:471
+#: aasrp/form.py:388 aasrp/models.py:352 aasrp/models.py:469
 msgid "Reject reason"
 msgstr ""
 
@@ -232,8 +232,8 @@ msgid ""
 "accepted."
 msgstr ""
 
-#: aasrp/form.py:472 aasrp/models.py:468 aasrp/models.py:475
-#: aasrp/models.py:527
+#: aasrp/form.py:472 aasrp/models.py:466 aasrp/models.py:473
+#: aasrp/models.py:525
 #: aasrp/templates/aasrp/ajax-render/srp-request-additional-information.html:104
 msgid "Comment"
 msgstr ""
@@ -243,11 +243,11 @@ msgid ""
 "Disable notifications. (Auth and Discord, if a relevant module is installed)"
 msgstr ""
 
-#: aasrp/helper/character.py:45 aasrp/helper/character.py:48
+#: aasrp/helper/character.py:44 aasrp/helper/character.py:47
 msgid "Unknown character"
 msgstr ""
 
-#: aasrp/helper/character.py:72
+#: aasrp/helper/character.py:71
 msgid "Copy character name to clipboard"
 msgstr ""
 
@@ -446,107 +446,107 @@ msgstr ""
 msgid "{character_name} ({user_name}) SRP request for: {ship} ({request_code})"
 msgstr ""
 
-#: aasrp/models.py:440 aasrp/models.py:501
+#: aasrp/models.py:438 aasrp/models.py:499
 msgid "SRP request"
 msgstr ""
 
-#: aasrp/models.py:443
+#: aasrp/models.py:441
 msgid "Insurance level"
 msgstr ""
 
-#: aasrp/models.py:445
+#: aasrp/models.py:443
 msgid "Insurance cost"
 msgstr ""
 
-#: aasrp/models.py:446
+#: aasrp/models.py:444
 #: aasrp/templates/aasrp/ajax-render/srp-request-additional-information.html:58
 #: aasrp/templates/aasrp/view-requests.html:42
 msgid "Insurance payout"
 msgstr ""
 
-#: aasrp/models.py:454
+#: aasrp/models.py:452
 msgid "Ship insurance"
 msgstr ""
 
-#: aasrp/models.py:455
+#: aasrp/models.py:453
 msgid "Ship insurances"
 msgstr ""
 
-#: aasrp/models.py:469
+#: aasrp/models.py:467
 msgid "SRP request added"
 msgstr ""
 
-#: aasrp/models.py:472
+#: aasrp/models.py:470
 msgid "Status changed"
 msgstr ""
 
-#: aasrp/models.py:473
+#: aasrp/models.py:471
 msgid "Reviser comment"
 msgstr ""
 
-#: aasrp/models.py:481
+#: aasrp/models.py:479
 msgid "Comment type"
 msgstr ""
 
 #. Translators: This is the time when the comment was made
-#: aasrp/models.py:509
+#: aasrp/models.py:507
 msgid "Comment time"
 msgstr ""
 
 #. Translators: New SRP request status that might have been set
-#: aasrp/models.py:518
+#: aasrp/models.py:516
 msgid "New SRP request status"
 msgstr ""
 
-#: aasrp/models.py:528
+#: aasrp/models.py:526
 msgid "Comments"
 msgstr ""
 
-#: aasrp/models.py:543
+#: aasrp/models.py:541
 #: aasrp/templates/aasrp/ajax-render/srp-request-additional-information.html:103
 msgid "User"
 msgstr ""
 
-#: aasrp/models.py:547
+#: aasrp/models.py:545
 msgid "Disable notifications"
 msgstr ""
 
-#: aasrp/models.py:556 aasrp/models.py:557
+#: aasrp/models.py:554 aasrp/models.py:555
 msgid "User settings"
 msgstr ""
 
-#: aasrp/models.py:571
+#: aasrp/models.py:569
 msgid "SRP team Discord channel ID"
 msgstr ""
 
-#: aasrp/models.py:574
+#: aasrp/models.py:572
 msgid "Loss value source"
 msgstr ""
 
-#: aasrp/models.py:581
+#: aasrp/models.py:579
 msgid "Fitted value (Ship and Fitting)"
 msgstr ""
 
-#: aasrp/models.py:582
+#: aasrp/models.py:580
 msgid "Total value (Ship, Fitting and Cargo)"
 msgstr ""
 
-#: aasrp/models.py:595
+#: aasrp/models.py:593
 msgid ""
 "The source for the loss value of a killmail. Fitted value is the value of "
 "the ship and its fitting. Total value is the value of the ship, its fitting "
 "and the cargo. (Default: Total value)"
 msgstr ""
 
-#: aasrp/models.py:612
+#: aasrp/models.py:610
 msgid "Setting"
 msgstr ""
 
-#: aasrp/models.py:613
+#: aasrp/models.py:611
 msgid "Settings"
 msgstr ""
 
-#: aasrp/models.py:623
+#: aasrp/models.py:621
 msgid "AA-SRP settings"
 msgstr ""
 


### PR DESCRIPTION
## [5.1.0] - 2026-07-09

> [!IMPORTANT]
> 
> **This version needs Alliance Auth v5.2.0 or newer!**
> 
> Please make sure to update your Alliance Auth instance **before** you install this
> version; otherwise, an update to Alliance Auth will be pulled in unsupervised.

### Changed

- Migrated to Alliance Auth proxy models for `Permission`, `User` and `Group`