### PR TITLE
[CHANGE] Use `pk` instead of `id` when referring to the primary key

### DIFF
--- a/.github/workflows/automated-checks.yml
+++ b/.github/workflows/automated-checks.yml
@@ -3,7 +3,7 @@ name: Tests
 env:
   COVERAGE_DATABASE_VERSION: mariadb:10.11
   COVERAGE_PYTHON_VERSION: 3.12
-  NODE_VERSION: 24 # [LTS] End of Life: 30 Apr 2028 (https://endoflife.date/nodejs)
+  NODE_VERSION: 26 # [LTS] End of Life: 30 Apr 2029 (https://endoflife.date/nodejs)
   REDIS_VERSION: latest
 
 on:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,4 +58,5 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           # The name of the file(s) to upload
           files: |
-            dist/*
+            dist/*.tar.gz
+            dist/*.whl

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@
 # Set the default language versions for the hooks
 default_language_version:
   python: python3  # Force all Python hooks to use Python 3
-  node: 24.14.0  # Force all Node hooks to use this specific Node version
+  node: 26.3.0  # Force all Node hooks to use this specific Node version
 
 # https://pre-commit.ci/
 ci:
@@ -68,7 +68,7 @@ repos:
         name: Check for large files
         description: Check for large files that were added to the repository.
         args:
-          - --maxkb=1000
+          - --maxkb=2048  # 2 MB
 
       - id: detect-private-key
         name: Detect private key
@@ -120,8 +120,10 @@ repos:
         name: End of file fixer
         description: Ensure that files end with a newline.
 
-  - repo: https://github.com/eslint/eslint
-    rev: 9089853a593d6c7c0f11367da08a829e0ddfe092  # frozen: v10.6.0
+#  - repo: https://github.com/eslint/eslint
+#    rev: 9089853a593d6c7c0f11367da08a829e0ddfe092  # frozen: v10.6.0
+  - repo: https://github.com/pre-commit/mirrors-eslint
+    rev: 8763fc929b6232999d541a3d8eb49965a6b71afb  # frozen: v10.6.0
     hooks:
       - id: eslint
         name: ESLint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,10 @@ Section Order:
 
 <!-- Your changes go here -->
 
+### Changed
+
+- Use `pk` instead of `id` when referring to the primary key of a model instance, since `id` is not guaranteed to be the primary key in Django.
+
 ## [5.1.0] - 2026-07-09
 
 > [!IMPORTANT]

--- a/aasrp/templates/aasrp/partials/datatables/view-own-requests/column-ship.html
+++ b/aasrp/templates/aasrp/partials/datatables/view-own-requests/column-ship.html
@@ -1,5 +1,5 @@
 {% load evelinks %}
 
 <a href="{{ row.killboard_link }}" target="_blank">
-    <img class="aasrp-evetype-icon rounded" src="{{ row.ship.id|type_render_url:32 }}" alt="Eagle" loading="lazy"><span>{{ row.ship.name }}</span>
+    <img class="aasrp-evetype-icon rounded" src="{{ row.ship.pk|type_render_url:32 }}" alt="{{ row.ship.name }}" loading="lazy"><span>{{ row.ship.name }}</span>
 </a>

--- a/aasrp/templates/aasrp/partials/view-own-requests/datatables-filter.html
+++ b/aasrp/templates/aasrp/partials/view-own-requests/datatables-filter.html
@@ -23,7 +23,7 @@
                     <option value="">{% translate "All ships" %}</option>
 
                     {% for ship in ships %}
-                        <option value="{{ ship.id }}">{{ ship.name }}</option>
+                        <option value="{{ ship.pk }}">{{ ship.name }}</option>
                     {% endfor %}
                 </select>
             </div>

--- a/aasrp/tests/test_admin.py
+++ b/aasrp/tests/test_admin.py
@@ -308,7 +308,7 @@ class TestFleetTypeAdmin(BaseTestCase):
 
         fleet_type_1 = FleetType.objects.create(name="Fleet A", is_enabled=False)
         fleet_type_2 = FleetType.objects.create(name="Fleet B", is_enabled=False)
-        queryset = FleetType.objects.filter(id__in=[fleet_type_1.id, fleet_type_2.id])
+        queryset = FleetType.objects.filter(pk__in=[fleet_type_1.pk, fleet_type_2.pk])
         request = SimpleNamespace()
 
         with (
@@ -332,7 +332,7 @@ class TestFleetTypeAdmin(BaseTestCase):
         """
 
         fleet_type = FleetType.objects.create(name="Fleet C", is_enabled=False)
-        queryset = FleetType.objects.filter(id=fleet_type.id)
+        queryset = FleetType.objects.filter(pk=fleet_type.pk)
         request = SimpleNamespace()
 
         with (
@@ -356,7 +356,7 @@ class TestFleetTypeAdmin(BaseTestCase):
 
         fleet_type_1 = FleetType.objects.create(name="Fleet D", is_enabled=True)
         fleet_type_2 = FleetType.objects.create(name="Fleet E", is_enabled=True)
-        queryset = FleetType.objects.filter(id__in=[fleet_type_1.id, fleet_type_2.id])
+        queryset = FleetType.objects.filter(pk__in=[fleet_type_1.pk, fleet_type_2.pk])
         request = SimpleNamespace()
 
         with (
@@ -380,7 +380,7 @@ class TestFleetTypeAdmin(BaseTestCase):
         """
 
         fleet_type = FleetType.objects.create(name="Fleet F", is_enabled=True)
-        queryset = FleetType.objects.filter(id=fleet_type.id)
+        queryset = FleetType.objects.filter(pk=fleet_type.pk)
         request = SimpleNamespace()
 
         with (

--- a/aasrp/tests/test_views_datatables.py
+++ b/aasrp/tests/test_views_datatables.py
@@ -130,13 +130,13 @@ class TestOwnSrpRequestsView(BaseTestCase):
         )
 
     def test_returns_queryset_filtered_by_ship(self):
-        ship = ItemType.objects.create(id=12345, name="TestShip")
+        ship = ItemType.objects.create(pk=12345, name="TestShip")
         SrpRequest.objects.create(creator=self.user, ship=ship, srp_link=self.srp_link)
         SrpRequest.objects.create(creator=self.user, srp_link=self.srp_link)
-        self.request.GET = QueryDict(f"filter_ship={ship.id}")
+        self.request.GET = QueryDict(f"filter_ship={ship.pk}")
         queryset = self.view.get_model_qs(self.request)
         self.assertEqual(queryset.count(), 1)
-        self.assertEqual(queryset.first().ship.id, ship.id)
+        self.assertEqual(queryset.first().ship.pk, ship.pk)
 
     def test_returns_full_queryset_when_no_filters_applied(self):
         SrpRequest.objects.create(creator=self.user, srp_link=self.srp_link)

--- a/aasrp/views/ajax.py
+++ b/aasrp/views/ajax.py
@@ -167,7 +167,7 @@ def srp_link_view_requests_data(request: WSGIRequest, srp_code: str) -> JsonResp
         # Generate a killboard link with the ship's render icon if available
         if srp_request.killboard_link:
             ship_render_icon_html = get_type_render_url_from_type_id(
-                evetype_id=srp_request.ship.id,
+                evetype_id=srp_request.ship.pk,
                 evetype_name=srp_request.ship.name,
                 size=32,
                 as_html=True,
@@ -269,7 +269,7 @@ def srp_request_additional_information(
 
     # Generate the ship render icon HTML for the SRP request
     ship_render_icon_html = get_type_render_url_from_type_id(
-        evetype_id=srp_request.ship.id,
+        evetype_id=srp_request.ship.pk,
         evetype_name=srp_request.ship.name,
         size=64,
         as_html=True,

--- a/aasrp/views/datatables.py
+++ b/aasrp/views/datatables.py
@@ -90,6 +90,6 @@ class OwnSrpRequestsView(PermissionRequiredMixin, DataTablesView):
             qs = qs.filter(character__character_id=filter_character)
 
         if filter_ship:
-            qs = qs.filter(ship__id=filter_ship)
+            qs = qs.filter(ship__pk=filter_ship)
 
         return qs

--- a/aasrp/views/general.py
+++ b/aasrp/views/general.py
@@ -105,7 +105,7 @@ def view_own_requests(request: WSGIRequest) -> HttpResponse:
         .order_by("character__character_name")
     )
     ships = (
-        ItemType.objects.filter(id__in=qs.values_list("ship", flat=True))
+        ItemType.objects.filter(pk__in=qs.values_list("ship", flat=True))
         .distinct()
         .order_by("name")
     )


### PR DESCRIPTION
## Description

### Changed

- Use `pk` instead of `id` when referring to the primary key of a model instance, since `id` is not guaranteed to be the primary key in Django.

## Type of Change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
